### PR TITLE
Set up beta release packaging and distribution workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.github export-ignore
+/.gitignore export-ignore
+/CHANGELOG.md export-ignore
+/README.md export-ignore
+/WowSimsGearHelper_icon.png export-ignore
+/README.maintainer.md export-ignore
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build addon zip
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ADDON_DIR="WowSimsGearHelper"
+          VERSION="${GITHUB_REF_NAME#v}"
+          ZIP_NAME="${ADDON_DIR}-${VERSION}.zip"
+
+          mkdir -p dist "${ADDON_DIR}"
+
+          # Build package from tracked files while honoring .gitattributes export-ignore.
+          git archive --format=tar --worktree-attributes HEAD | tar -x -C "${ADDON_DIR}"
+          zip -r "dist/${ZIP_NAME}" "${ADDON_DIR}"
+
+          echo "artifact=dist/${ZIP_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.package.outputs.artifact }}
+          generate_release_notes: true
+
+      - name: Publish to CurseForge
+        if: ${{ secrets.CURSEFORGE_API_TOKEN != '' && vars.CURSEFORGE_PROJECT_ID != '' }}
+        uses: itsmeow/curseforge-upload@v3
+        with:
+          api-token: ${{ secrets.CURSEFORGE_API_TOKEN }}
+          project-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
+          game-endpoint: wow
+          file-path: ${{ steps.package.outputs.artifact }}
+          changelog: "See GitHub release notes for ${{ github.ref_name }}."
+          changelog-type: markdown
+          release-type: beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.1.0] - 2026-02-22
+
+### Added
+- Initial release preparation for distribution and tester onboarding.
+- Tag-based GitHub Actions workflow that builds and publishes versioned zip artifacts.
+
+### Changed
+- Updated project version metadata to `0.1.0` for initial beta release.
+- Expanded README with distribution instructions.
+
+## [0.0.4] - 2026-02-22
+
+### Fixed
+- Socket guidance now resolves the active socket target more reliably by using the socket UI item title when slot/link fields are unavailable.
+- Socket highlights now retarget correctly when manually switching items in the socket UI (for items that still have pending socket tasks).
+- Socket highlights now clear when the socket UI is closed, preventing stale bag/socket indicators.
+- Socket indicator labels (`E`, `S`, and socket indices) now render consistently after recent highlight changes.
+- JP commendation guidance highlight is now cleared when other task flows (socket/enchant/socket-hint actions) are started, reducing conflicting overlays.
+
+### Changed
+- Shopping list search icon sizing is now controlled separately from button sizing, so the icon no longer overflows the button.
+- Added `SocketDiagnostics()` to the debug command list to simplify in-game socket-state troubleshooting.

--- a/Core.lua
+++ b/Core.lua
@@ -3,7 +3,7 @@ local WSGH = _G.WowSimsGearHelper or {}
 _G.WowSimsGearHelper = WSGH
 
 WSGH.ADDON_NAME = ADDON_NAME
-WSGH.VERSION = "0.0.4"
+WSGH.VERSION = "0.1.0"
 
 local function EnsureDB()
   if type(_G.WowSimsGearHelperDB) ~= "table" then
@@ -188,3 +188,4 @@ events:SetScript("OnEvent", function(_, event, name)
     Print("Loaded. /wsgh to toggle.")
   end
 end)
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 WowSims Gear Helper
-![Version](https://img.shields.io/badge/version-0.0.4-blue)
+![Version](https://img.shields.io/badge/version-0.1.0-blue)
 ===================
-
 
 <img src="WowSimsGearHelper_icon.png" alt="WowSims Gear Helper icon" width="128">
 
@@ -28,9 +27,14 @@ If your bag addon is not listed, open a feature request.
 
 Installation
 ------------
-1) Download or clone this repository.
-2) Copy `WowSimsGearHelper` into:
-   `World of Warcraft/_classic_/Interface/AddOns/`
+### For testers (recommended)
+1) Install via CurseForge client.
+2) Search for `WowSims Gear Helper` and install.
+
+### Manual zip install
+1) Download the latest release zip from GitHub Releases.
+2) Extract so the folder layout is:
+   `World of Warcraft/_classic_/Interface/AddOns/WowSimsGearHelper/`
 3) Launch the game and enable the addon.
 
 Usage

--- a/WowSimsGearHelper.toc
+++ b/WowSimsGearHelper.toc
@@ -2,7 +2,7 @@
 ## Title: WowSims Gear Helper
 ## Notes: Paste WowSims exports and guide gear changes with highlights and shopping lists.
 ## Author: Blazz
-## Version: 0.0.4
+## Version: 0.1.0
 ## SavedVariablesPerCharacter: WowSimsGearHelperDB
 
 Libs/Json.lua
@@ -34,3 +34,4 @@ UI/Shopping.lua
 UI/Settings.lua
 UI/ImportDialog.lua
 UI.lua
+


### PR DESCRIPTION
## Summary
Prepare `WowSimsGearHelper` for distributable beta releases and CurseForge publishing.

## What changed
- Added GitHub Actions release workflow: `.github/workflows/release.yml`
  - Triggers on `v*` tags
  - Builds versioned addon zip artifact
  - Creates GitHub Release
  - Optionally uploads to CurseForge when configured
- Added packaging exclusions via `.gitattributes` (`export-ignore`)
- Added `CHANGELOG.md` baseline for release notes/history
- Updated version metadata to `0.1.0`:
  - `Core.lua`
  - `WowSimsGearHelper.toc`
  - `README.md` badge
- Updated public install instructions in `README.md` for tester-friendly distribution

## Why
Lower the barrier for testers and early adopters by making installation and releases consistent, versioned, and repeatable.

- Next step is tagging from `main` (e.g. `v0.1.0-beta.1`) and confirming:
  - GitHub Release artifact is generated
  - CurseForge upload succeeds (if token/project ID are configured)

Closes #5 (hopefully)