### PR TITLE
[Bug] Fix missing extra-socket workflow and show addon version in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.1.1] - 04 Mar, 2026
+
+### Added
+- Main window title and settings panel now display the current addon version for easier in-game verification.
+
+### Fixed
+- Extra-socket workflows now defer blocked gem socket tasks until the missing socket is added, instead of treating them as immediately actionable.
+- Socket rows now render deferred gems as blocked/not-ready with tooltip guidance to add the socket first.
+- Shopping list item resolution and need counts now include deferred gem tasks so required gems remain visible while waiting on socket creation.
+
+### Changed
+- Diff task output now emits explicit `ADD_SOCKET` tasks for rows missing planned sockets, improving task flow and diagnostics.
+
 ## [0.1.0] - 22 Feb, 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 - Extra-socket workflows now defer blocked gem socket tasks until the missing socket is added, instead of treating them as immediately actionable.
 - Socket rows now render deferred gems as blocked/not-ready with tooltip guidance to add the socket first.
 - Shopping list item resolution and need counts now include deferred gem tasks so required gems remain visible while waiting on socket creation.
+- Socket-hint subtitle fallback now avoids raw `item <id>` text when item data is uncached by requesting item data and using existing hint text until names resolve.
 
 ### Changed
 - Diff task output now emits explicit `ADD_SOCKET` tasks for rows missing planned sockets, improving task flow and diagnostics.

--- a/Core.lua
+++ b/Core.lua
@@ -3,7 +3,7 @@ local WSGH = _G.WowSimsGearHelper or {}
 _G.WowSimsGearHelper = WSGH
 
 WSGH.ADDON_NAME = ADDON_NAME
-WSGH.VERSION = "0.1.0"
+WSGH.VERSION = "0.1.1"
 
 local function EnsureDB()
   if type(_G.WowSimsGearHelperDB) ~= "table" then

--- a/Diff/Engine.lua
+++ b/Diff/Engine.lua
@@ -47,8 +47,36 @@ local function GetExpectedUpgradeStep(planSlot)
   return trailingNumber
 end
 
-local function BuildSocketTasksForSlot(planSlot, equippedSlot, bagIndex)
+local function MaxExpectedSocketIndex(planSlot)
+  local maxIdx = 0
+  for socketIndex in pairs(planSlot.expectedGemsByIndex or {}) do
+    if socketIndex > maxIdx then
+      maxIdx = socketIndex
+    end
+  end
+  return maxIdx
+end
+
+local function EffectivePhysicalSocketCount(slotMeta, planSlot, equippedSlot)
+  local physicalSockets = tonumber(equippedSlot.socketCount) or 0
+  local maxExpected = MaxExpectedSocketIndex(planSlot)
+
+  -- Belt edge case: when a buckle is applied, item data can miss the extra socket.
+  if slotMeta.slotId == 6 and equippedSlot.hasBeltBuckle and maxExpected > physicalSockets then
+    physicalSockets = maxExpected
+  end
+
+  return math.max(0, physicalSockets), maxExpected
+end
+
+local function SupportsExtraSocketHints(slotId)
+  slotId = tonumber(slotId) or 0
+  return slotId == 6 or slotId == 9 or slotId == 10 or slotId == 16 or slotId == 17
+end
+
+local function BuildSocketTasksForSlot(slotMeta, planSlot, equippedSlot, bagIndex)
   local tasks = {}
+  local deferredTasks = {}
 
   local expectedItemId = tonumber(planSlot.expectedItemId) or 0
   local equippedItemId = tonumber(equippedSlot.itemId) or 0
@@ -65,40 +93,63 @@ local function BuildSocketTasksForSlot(planSlot, equippedSlot, bagIndex)
 
   local want = planSlot.expectedGemsByIndex or {}
   local have = equippedSlot.gemsByIndex or {}
+  local physicalSockets = tonumber(equippedSlot.socketCount) or 0
+  local maxExpected = MaxExpectedSocketIndex(planSlot)
+  local hasExtraSocketHintPath = SupportsExtraSocketHints(slotMeta.slotId)
+  if hasExtraSocketHintPath then
+    physicalSockets, maxExpected = EffectivePhysicalSocketCount(slotMeta, planSlot, equippedSlot)
+  end
 
   for socketIndex, wantGemId in pairs(want) do
+    socketIndex = tonumber(socketIndex) or 0
     wantGemId = tonumber(wantGemId) or 0
-    if wantGemId ~= 0 then
-      local haveGemId = tonumber(have[socketIndex]) or 0
+    if wantGemId ~= 0 and socketIndex > 0 then
+      local missingPhysicalSocket = hasExtraSocketHintPath and maxExpected > physicalSockets and socketIndex > physicalSockets
+      if not missingPhysicalSocket then
+        local haveGemId = tonumber(have[socketIndex]) or 0
 
-      local status = WSGH.Const.STATUS_OK
-      local locations = bagIndex and bagIndex[wantGemId] or nil
+        local status = WSGH.Const.STATUS_OK
+        local locations = bagIndex and bagIndex[wantGemId] or nil
 
-      if haveGemId == 0 then
-        status = WSGH.Const.STATUS_EMPTY
-      elseif haveGemId ~= wantGemId then
-        status = WSGH.Const.STATUS_WRONG
+        if haveGemId == 0 then
+          status = WSGH.Const.STATUS_EMPTY
+        elseif haveGemId ~= wantGemId then
+          status = WSGH.Const.STATUS_WRONG
+        end
+
+        if status ~= WSGH.Const.STATUS_OK and (not locations or #locations == 0) then
+          status = WSGH.Const.STATUS_MISSING
+        end
+
+        tasks[#tasks + 1] = {
+          type = "SOCKET_GEM",
+          slotId = planSlot.slotId,
+          slotKey = planSlot.slotKey,
+          itemId = equippedItemId,
+
+          socketIndex = socketIndex,
+
+          wantGemId = wantGemId,
+          haveGemId = haveGemId,
+
+          status = status,
+
+          bagLocations = locations, -- may be nil
+        }
+      else
+        deferredTasks[#deferredTasks + 1] = {
+          type = "SOCKET_GEM",
+          slotId = planSlot.slotId,
+          slotKey = planSlot.slotKey,
+          itemId = equippedItemId,
+          socketIndex = socketIndex,
+          wantGemId = wantGemId,
+          haveGemId = 0,
+          status = WSGH.Const.STATUS_WRONG,
+          blockedByMissingSocket = true,
+          bagLocations = bagIndex and bagIndex[wantGemId] or nil,
+        }
       end
-
-      if status ~= WSGH.Const.STATUS_OK and (not locations or #locations == 0) then
-        status = WSGH.Const.STATUS_MISSING
-      end
-
-      tasks[#tasks + 1] = {
-        type = "SOCKET_GEM",
-        slotId = planSlot.slotId,
-        slotKey = planSlot.slotKey,
-        itemId = equippedItemId,
-
-        socketIndex = socketIndex,
-
-        wantGemId = wantGemId,
-        haveGemId = haveGemId,
-
-        status = status,
-
-        bagLocations = locations, -- may be nil
-      }
     end
   end
 
@@ -106,8 +157,11 @@ local function BuildSocketTasksForSlot(planSlot, equippedSlot, bagIndex)
   table.sort(tasks, function(a, b)
     return a.socketIndex < b.socketIndex
   end)
+  table.sort(deferredTasks, function(a, b)
+    return a.socketIndex < b.socketIndex
+  end)
 
-  return tasks
+  return tasks, deferredTasks
 end
 
 local function BuildEnchantTasksForSlot(planSlot, equippedSlot, bagIndex)
@@ -249,16 +303,6 @@ local function ComputeSocketCount(planSlot, equippedSlot)
   return math.min(math.max(count, 0), WSGH.Const.MAX_SOCKETS_RENDER)
 end
 
-local function MaxExpectedSocketIndex(planSlot)
-  local maxIdx = 0
-  for socketIndex in pairs(planSlot.expectedGemsByIndex or {}) do
-    if socketIndex > maxIdx then
-      maxIdx = socketIndex
-    end
-  end
-  return maxIdx
-end
-
 local function SocketHintForSlot(slotMeta, planSlot, equippedSlot, computedSocketCount)
   local expectedItemId = tonumber(planSlot.expectedItemId) or 0
   local equippedItemId = tonumber(equippedSlot.itemId) or 0
@@ -266,13 +310,7 @@ local function SocketHintForSlot(slotMeta, planSlot, equippedSlot, computedSocke
     return nil
   end
 
-  local physicalSockets = tonumber(equippedSlot.socketCount) or 0
-  local maxExpected = MaxExpectedSocketIndex(planSlot)
-
-  -- Belt edge case: when a buckle is applied, item data can miss the extra socket.
-  if slotMeta.slotId == 6 and equippedSlot.hasBeltBuckle and maxExpected > physicalSockets then
-    physicalSockets = maxExpected
-  end
+  local physicalSockets, maxExpected = EffectivePhysicalSocketCount(slotMeta, planSlot, equippedSlot)
   -- Weapon sockets rely on reported stats; no extra overrides.
 
   local missingSockets = math.max(0, maxExpected - physicalSockets)
@@ -310,10 +348,7 @@ local function SocketHintForSlot(slotMeta, planSlot, equippedSlot, computedSocke
 
   -- Sha-Touched / Throne of Thunder weapon socket.
   if slotId == 16 or slotId == 17 then
-    if physicalSockets == 0 then
-      return { text = "If this is a Sha-Touched/ToT weapon, use Eye of the Black Prince (93403)", itemId = 93403, missing = missingSockets }
-    end
-    return nil
+    return { text = "If this is a Sha-Touched/ToT weapon, use Eye of the Black Prince (93403)", itemId = 93403, missing = missingSockets }
   end
 
   return { text = ("Add an extra socket (plan has %d, item has %d)"):format(maxExpected, physicalSockets), itemId = nil, missing = missingSockets }
@@ -437,7 +472,7 @@ function WSGH.Diff.Engine.Build(plan, equipped, bagIndex)
     local eqSlot = equipped[slotId]
 
     if planSlot and eqSlot then
-      local socketTasks = BuildSocketTasksForSlot(planSlot, eqSlot, bagIndex)
+      local socketTasks, deferredSocketTasks = BuildSocketTasksForSlot(slotMeta, planSlot, eqSlot, bagIndex)
       local enchantTasks = BuildEnchantTasksForSlot(planSlot, eqSlot, bagIndex)
       local upgradeTasks = BuildUpgradeTasksForSlot(planSlot, eqSlot)
       local rowStatus = ComputeRowStatus(planSlot, eqSlot, socketTasks, enchantTasks, upgradeTasks)
@@ -465,6 +500,19 @@ function WSGH.Diff.Engine.Build(plan, equipped, bagIndex)
           result.tasks[#result.tasks + 1] = t
         end
       end
+      if socketHint and tonumber(socketHint.missing) and tonumber(socketHint.missing) > 0 then
+        result.tasks[#result.tasks + 1] = {
+          type = "ADD_SOCKET",
+          slotId = planSlot.slotId,
+          slotKey = planSlot.slotKey,
+          itemId = eqSlot.itemId,
+          status = WSGH.Const.STATUS_WRONG,
+          missingSockets = tonumber(socketHint.missing) or 0,
+          socketHintItemId = socketHint.itemId,
+          socketHintExtraItemId = socketHint.extraItemId,
+          socketHintExtraItemCount = socketHint.extraItemCount,
+        }
+      end
 
       result.rows[#result.rows + 1] = {
         slotId = slotId,
@@ -487,6 +535,7 @@ function WSGH.Diff.Engine.Build(plan, equipped, bagIndex)
         equippedUpgradeLevel = tonumber(eqSlot.upgradeLevel) or 0,
         equippedUpgradeMax = tonumber(eqSlot.upgradeMax) or 0,
         socketTasks = socketTasks,
+        deferredSocketTasks = deferredSocketTasks,
         nextTask = nextTask,
         socketCount = computedSocketCount,
         physicalSocketCount = tonumber(eqSlot.socketCount) or 0,
@@ -541,6 +590,14 @@ function WSGH.Debug.DumpDiffRow(slotId)
             tostring(t.wantGemId),
             tostring(t.haveGemId),
             tostring(t.status)
+          ))
+        end
+      end
+      if row.deferredSocketTasks then
+        for _, t in ipairs(row.deferredSocketTasks) do
+          WSGH.Util.Print(("[deferred %d] want=%s blocked=1"):format(
+            tonumber(t.socketIndex) or 0,
+            tostring(t.wantGemId)
           ))
         end
       end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 WowSims Gear Helper
-![Version](https://img.shields.io/badge/version-0.1.0-blue)
+![Version](https://img.shields.io/badge/version-0.1.1-blue)
 ===================
 
 <img src="WowSimsGearHelper_icon.png" alt="WowSims Gear Helper icon" width="128">

--- a/UI.lua
+++ b/UI.lua
@@ -1144,7 +1144,8 @@ function WSGH.UI.Init()
 
   local title = mainFrame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
   title:SetPoint("TOPLEFT", 18, -16)
-  title:SetText("WowSims Gear Helper")
+  local addonVersion = WSGH.Util and WSGH.Util.GetAddonVersion and WSGH.Util.GetAddonVersion() or (WSGH.VERSION or "unknown")
+  title:SetText(("WowSims Gear Helper v%s"):format(tostring(addonVersion)))
 
   local close = CreateFrame("Button", nil, mainFrame, "UIPanelCloseButton")
   close:SetPoint("TOPRIGHT", -5, -5)

--- a/UI.lua
+++ b/UI.lua
@@ -1144,8 +1144,12 @@ function WSGH.UI.Init()
 
   local title = mainFrame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
   title:SetPoint("TOPLEFT", 18, -16)
+  title:SetText("WowSims Gear Helper")
+
   local addonVersion = WSGH.Util and WSGH.Util.GetAddonVersion and WSGH.Util.GetAddonVersion() or (WSGH.VERSION or "unknown")
-  title:SetText(("WowSims Gear Helper v%s"):format(tostring(addonVersion)))
+  local versionLabel = mainFrame:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+  versionLabel:SetPoint("LEFT", title, "RIGHT", 8, -1)
+  versionLabel:SetText(("v%s"):format(tostring(addonVersion)))
 
   local close = CreateFrame("Button", nil, mainFrame, "UIPanelCloseButton")
   close:SetPoint("TOPRIGHT", -5, -5)

--- a/UI/Rows.lua
+++ b/UI/Rows.lua
@@ -52,13 +52,24 @@ local function SocketHintDescription(rowData)
 
   local desc
   if hintItemId ~= 0 then
-    local name = GetItemInfo(hintItemId) or ("item " .. hintItemId)
-    desc = ("Add missing socket: %s."):format(name)
+    local name = GetItemInfo(hintItemId)
+    if not name and C_Item and C_Item.RequestLoadItemDataByID then
+      C_Item.RequestLoadItemDataByID(hintItemId)
+    end
+    if name then
+      desc = ("Add missing socket: %s."):format(name)
+    else
+      desc = rowData.socketHintText or ("Add missing socket: item " .. hintItemId .. ".")
+    end
   else
     desc = "Add missing socket: Blacksmithing."
   end
   if extraId ~= 0 and extraCount > 0 then
-    local extraName = GetItemInfo(extraId) or ("item " .. extraId)
+    local extraName = GetItemInfo(extraId)
+    if not extraName and C_Item and C_Item.RequestLoadItemDataByID then
+      C_Item.RequestLoadItemDataByID(extraId)
+    end
+    extraName = extraName or ("item " .. extraId)
     desc = desc .. (" Requires %d x %s."):format(extraCount, extraName)
   end
   return desc

--- a/UI/Rows.lua
+++ b/UI/Rows.lua
@@ -405,9 +405,16 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
   end
 
   local tasksBySocket = {}
+  local deferredBySocket = {}
   local maxTaskIndex = 0
   for _, task in ipairs(rowData.socketTasks or {}) do
     tasksBySocket[task.socketIndex] = task
+    if task.socketIndex > maxTaskIndex then
+      maxTaskIndex = task.socketIndex
+    end
+  end
+  for _, task in ipairs(rowData.deferredSocketTasks or {}) do
+    deferredBySocket[task.socketIndex] = task
     if task.socketIndex > maxTaskIndex then
       maxTaskIndex = task.socketIndex
     end
@@ -428,6 +435,7 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
   for i = 1, WSGH.Const.MAX_SOCKETS_RENDER do
     local socketFrame = rowFrame.socketFrames[i]
     local task = tasksBySocket[i]
+    local deferredTask = deferredBySocket[i]
 
     if i <= socketCount and task then
       local gemIcon = GetGemIcon(task.wantGemId)
@@ -440,6 +448,24 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
       socketFrame:Show()
       socketFrame:SetScript("OnEnter", function(self)
         ShowTooltip(self, task.wantGemId)
+      end)
+      socketFrame:SetScript("OnLeave", GameTooltip_Hide)
+    elseif i <= socketCount and deferredTask then
+      local gemIcon = GetGemIcon(deferredTask.wantGemId)
+      socketFrame.icon:SetTexture(gemIcon or WSGH.Const.ICON_EMPTY_SOCKET)
+      socketFrame.status:SetTexture(WSGH.Const.ICON_NOTREADY)
+      socketFrame:Show()
+      socketFrame:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        local gemId = tonumber(deferredTask.wantGemId) or 0
+        if gemId ~= 0 then
+          local gemName = GetItemInfo(gemId) or ("gem " .. tostring(gemId))
+          GameTooltip:SetText(("Planned gem: %s"):format(gemName))
+        else
+          GameTooltip:SetText("Planned gem")
+        end
+        GameTooltip:AddLine("Socket missing on item. Add the extra socket first, then insert this gem.", 1, 0.2, 0.2, true)
+        GameTooltip:Show()
       end)
       socketFrame:SetScript("OnLeave", GameTooltip_Hide)
     elseif i <= socketCount then

--- a/UI/Settings.lua
+++ b/UI/Settings.lua
@@ -25,10 +25,15 @@ local function BuildOptionsPanel()
   desc:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -8)
   desc:SetText("Preferences")
 
+  local addonVersion = WSGH.Util and WSGH.Util.GetAddonVersion and WSGH.Util.GetAddonVersion() or (WSGH.VERSION or "unknown")
+  local versionText = optionsPanel:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+  versionText:SetPoint("TOPLEFT", desc, "BOTTOMLEFT", 0, -4)
+  versionText:SetText(("Version: %s"):format(tostring(addonVersion)))
+
   local preferences = GetPreferences() or {}
 
   local persistCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
-  persistCheck:SetPoint("TOPLEFT", desc, "BOTTOMLEFT", 0, -8)
+  persistCheck:SetPoint("TOPLEFT", versionText, "BOTTOMLEFT", 0, -8)
   persistCheck.Text:SetText("Save last import")
   persistCheck:SetChecked(preferences.persistImports or false)
   persistCheck:SetScript("OnClick", function(self)

--- a/UI/Shopping.lua
+++ b/UI/Shopping.lua
@@ -34,6 +34,9 @@ local function ResolveKnownNeededItemIdByName(itemName)
         addItemId(task.wantGemId)
       end
     end
+    for _, task in ipairs(row.deferredSocketTasks or {}) do
+      addItemId(task.wantGemId)
+    end
     for _, task in ipairs(row.enchantTasks or {}) do
       if task.status and task.status ~= WSGH.Const.STATUS_OK then
         addItemId(task.wantEnchantItemId)
@@ -588,6 +591,12 @@ function WSGH.UI.Shopping.UpdateShoppingList()
           end
         end
       end
+      for _, task in ipairs(row.deferredSocketTasks or {}) do
+        local wantGemId = tonumber(task.wantGemId) or 0
+        if wantGemId ~= 0 then
+          AccumulateNeed(wantGemId, 1, "Gems")
+        end
+      end
       for _, task in ipairs(row.enchantTasks or {}) do
         if task.status and task.status ~= WSGH.Const.STATUS_OK then
           local enchantItemId = tonumber(task.wantEnchantItemId) or 0
@@ -1132,6 +1141,11 @@ function WSGH.Debug.DumpShoppingItem(itemId)
     for _, row in ipairs(diff.rows) do
       for _, task in ipairs(row.socketTasks or {}) do
         if task.status and task.status ~= WSGH.Const.STATUS_OK and tonumber(task.wantGemId) == itemId then
+          needCount = needCount + 1
+        end
+      end
+      for _, task in ipairs(row.deferredSocketTasks or {}) do
+        if tonumber(task.wantGemId) == itemId then
           needCount = needCount + 1
         end
       end

--- a/Util.lua
+++ b/Util.lua
@@ -57,6 +57,21 @@ function WSGH.Util.Print(msg)
   DEFAULT_CHAT_FRAME:AddMessage(("|cff33ff99WSGH|r: %s"):format(tostring(msg)))
 end
 
+function WSGH.Util.GetAddonVersion()
+  local addonName = WSGH.ADDON_NAME
+  local version = nil
+  if type(GetAddOnMetadata) == "function" and type(addonName) == "string" and addonName ~= "" then
+    version = GetAddOnMetadata(addonName, "Version")
+  end
+  if type(version) ~= "string" or version == "" then
+    version = WSGH.VERSION
+  end
+  if type(version) ~= "string" or version == "" then
+    return "unknown"
+  end
+  return version
+end
+
 function WSGH.Util.OpenBagsForGuidance()
   local adapters = WSGH.UI and WSGH.UI.BagAdapters or nil
   if adapters and adapters.AreBagFramesVisible and adapters.AreBagFramesVisible() then

--- a/WowSimsGearHelper.toc
+++ b/WowSimsGearHelper.toc
@@ -2,7 +2,7 @@
 ## Title: WowSims Gear Helper
 ## Notes: Paste WowSims exports and guide gear changes with highlights and shopping lists.
 ## Author: Blazz
-## Version: 0.1.0
+## Version: 0.1.1
 ## SavedVariablesPerCharacter: WowSimsGearHelperDB
 
 Libs/Json.lua


### PR DESCRIPTION
## Summary
Improve missing extra-socket task handling so gem guidance, row state, and shopping needs stay accurate when a planned socket does not yet exist on the item.  
Also surface addon version info in-game and bump project version to `0.1.1`.

## What changed
- Diff/task engine improvements:
  - Added handling for “deferred” gem tasks when blocked by missing physical sockets
  - Added explicit `ADD_SOCKET` task emission for rows missing expected sockets
  - Improved socket count/hint logic for supported extra-socket slots (belt, bracer, gloves, weapons)
  - Added deferred-task visibility in debug row output
- Row UI improvements:
  - Render deferred gem sockets as blocked/not-ready
  - Added tooltip guidance to add socket first, then gem
- Shopping improvements:
  - Included deferred gem tasks in need resolution and shopping accumulation/debug counts
- Version visibility:
  - Main UI now shows addon version in the title area (muted style)
  - Settings panel now shows current addon version
  - Added shared version resolver helper
- Version/changelog metadata:
  - Bumped version to `0.1.1` in:
    - `Core.lua`
    - `WowSimsGearHelper.toc`
    - `README.md` badge
  - Added `0.1.1` changelog entry

## Why
Missing-extra-socket scenarios were functionally close but still ambiguous in task ordering and shopping visibility.  
This makes the flow explicit: create socket first, then apply deferred gems, with consistent UI/task/shopping behavior.

Closes #12
