### PR TITLE
Bumped addon metadata to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.1.3] - 03 Jun, 2026
+
+### Added
+- New highlight style options now include Blizzard-style glow plus light and strong autocast shine variants.
+
+### Fixed
+- Settings now open correctly from the main addon window on the current client.
+- Guidance no longer tries to reopen protected UIs from automatic inventory updates, avoiding post-patch blocked-action errors.
+- ArkInventory bag highlights now resolve visible item frames more reliably after recent client changes.
+
+### Changed
+- Bag and character highlight glows now use a bundled standalone glow library so the addon no longer depends on another addon providing the effect.
+- Blizzard-style glow coloring was adjusted to better match the familiar in-game yellow/gold alert look.
+
 ## [0.1.2-beta.3] - 07 May, 2026
 
 ### Changed

--- a/Core.lua
+++ b/Core.lua
@@ -3,7 +3,7 @@ local WSGH = _G.WowSimsGearHelper or {}
 _G.WowSimsGearHelper = WSGH
 
 WSGH.ADDON_NAME = ADDON_NAME
-WSGH.VERSION = "0.1.2-beta.3"
+WSGH.VERSION = "0.1.3"
 
 local function EnsureDB()
   if type(_G.WowSimsGearHelperDB) ~= "table" then

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 WowSims Gear Helper
 <!-- ![Alpha](https://img.shields.io/badge/alpha-0.1.2--alpha.2-blue) -->
 ![Alpha](https://img.shields.io/badge/alpha-none-lightgrey)
-![Beta](https://img.shields.io/badge/beta-0.1.2--beta.3-brightgreen)
+![Beta](https://img.shields.io/badge/beta-0.1.3-brightgreen)
 ===================
 
 <img src="WowSimsGearHelper_icon.png" alt="WowSims Gear Helper icon" width="128">
@@ -54,7 +54,7 @@ Please use GitHub Issues and include as much context as possible.
 
 Limitations
 -----------
-- Reforging is not handled. Use ReforgeLite: <https://www.curseforge.com/wow/addons/reforgelite>, an integration is planned to work with ReforgeLite from WSGH directly.
+- Reforging is not handled. Use ReforgeLite Classic: <https://www.curseforge.com/wow/addons/reforgelite-classic>, an integration is planned to work with ReforgeLite from WSGH directly.
 
 Attribution
 -----------

--- a/WowSimsGearHelper.toc
+++ b/WowSimsGearHelper.toc
@@ -1,8 +1,9 @@
-## Interface: 50503
+## Interface: 50504
 ## Title: WowSims Gear Helper
-## Notes: Paste WowSims exports and guide gear changes with highlights and shopping lists.
+## Notes: WSGH helps apply WowSims exports with guided gear changes, highlights, and shopping lists.
+## IconTexture: Interface\AddOns\WowSimsGearHelper\WowSimsGearHelper_icon.tga
 ## Author: Blazz
-## Version: 0.1.2-beta.3
+## Version: 0.1.3
 ## OptionalDeps: Masque
 ## SavedVariablesPerCharacter: WowSimsGearHelperDB
 


### PR DESCRIPTION
## Summary

Fix post-patch guidance, settings, and highlight regressions, and update addon metadata for `0.1.3`.

## What changed

- Fixed the settings button flow so the addon settings panel opens correctly from the main window.
- Fixed guidance progression so follow-up steps no longer trigger protected UI actions from automatic inventory updates.
- Improved bag highlight reliability after recent client changes, including ArkInventory item-frame resolution.
- Updated highlight styles and settings labels:
  - `Blizzard-style glow`
  - `Autocast shine (light)`
  - `Autocast shine (strong)`
  - `Label only`
- Adjusted highlight coloring to better match the familiar Blizzard yellow/gold glow.
- Updated addon metadata for `0.1.3`, including the current interface version, addon-list icon, README, and changelog.

## Why

Recent Blizzard/client changes introduced visible regressions in three areas:
- settings opening
- guidance flow around protected UI actions
- bag and character highlight behavior

This change restores those flows and keeps the addon behavior consistent on the current client.