### PR TITLE
Feature/allow user controlled task ordering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,12 @@ jobs:
     env:
       CURSEFORGE_API_TOKEN: ${{ secrets.CURSEFORGE_API_TOKEN }}
       CURSEFORGE_PROJECT_ID: ${{ vars.CURSEFORGE_PROJECT_ID }}
+      CURSEFORGE_GAME_VERSION_IDS: ${{ vars.CURSEFORGE_GAME_VERSION_IDS }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Determine release metadata
         id: meta
@@ -38,6 +41,42 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
           echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release channel branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_TYPE="${{ steps.meta.outputs.release_type }}"
+          TAG_SHA="${GITHUB_SHA}"
+          CONTAINING_BRANCHES="$(git branch -r --contains "$TAG_SHA" | sed 's/^[* ]*//')"
+
+          echo "Branches containing ${GITHUB_REF_NAME}:"
+          printf '%s\n' "$CONTAINING_BRANCHES"
+
+          case "$RELEASE_TYPE" in
+            alpha)
+              if ! printf '%s\n' "$CONTAINING_BRANCHES" | grep -Eq '^origin/feature/'; then
+                echo "Alpha tags must point to a commit on a feature/* branch."
+                exit 1
+              fi
+              ;;
+            beta)
+              if ! printf '%s\n' "$CONTAINING_BRANCHES" | grep -Eq '^origin/release/'; then
+                echo "Beta tags must point to a commit on a release/* branch."
+                exit 1
+              fi
+              ;;
+            release)
+              if ! printf '%s\n' "$CONTAINING_BRANCHES" | grep -Eq '^origin/main$'; then
+                echo "Stable release tags must point to a commit on main."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Unknown release type: $RELEASE_TYPE"
+              exit 1
+              ;;
+          esac
 
       - name: Build addon zip
         id: package
@@ -109,7 +148,7 @@ jobs:
             CURSEFORGE_CHANGELOG_BLOCK="Release ${VERSION}"
           fi
 
-          FULL_CHANGELOG_URL="https://github.com/${GITHUB_REPOSITORY}/blob/main/CHANGELOG.md"
+          FULL_CHANGELOG_URL="https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF_NAME}/CHANGELOG.md"
           CURSEFORGE_CHANGELOG_BLOCK="$(printf '[Full changelog](%s)\n\n%s' "$FULL_CHANGELOG_URL" "$CURSEFORGE_CHANGELOG_BLOCK")"
 
           {
@@ -130,14 +169,14 @@ jobs:
           prerelease: ${{ steps.meta.outputs.prerelease }}
 
       - name: Publish to CurseForge
-        if: ${{ env.CURSEFORGE_API_TOKEN != '' && env.CURSEFORGE_PROJECT_ID != '' }}
+        if: ${{ env.CURSEFORGE_API_TOKEN != '' && env.CURSEFORGE_PROJECT_ID != '' && env.CURSEFORGE_GAME_VERSION_IDS != '' }}
         uses: itsmeow/curseforge-upload@v3
         with:
           token: ${{ env.CURSEFORGE_API_TOKEN }}
           project_id: ${{ env.CURSEFORGE_PROJECT_ID }}
           game_endpoint: wow
           file_path: ${{ steps.package.outputs.artifact }}
-          game_versions: "14102"
+          game_versions: ${{ env.CURSEFORGE_GAME_VERSION_IDS }}
           changelog: ${{ steps.changelog.outputs.curseforge_body }}
           changelog_type: markdown
           release_type: ${{ steps.meta.outputs.release_type }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented in this file.
 
+## [1.3.0] - 16 Jun, 2026
+
+### Added
+- Added a task priority ordering UI with drag-and-drop rows.
+- Dragging task types in Settings saves a per-character priority order.
+- Task priority controls which row action is offered first when a slot has multiple kinds of work. Equipping the expected item remains the first prerequisite before task ordering applies.
+- Row badge task details follow the configured task order, including separate sections for enchants and tinkers.
+- The flat diff task list also follows the configured task type order, with equipped slot order used as the secondary sort.
+- Reforging defaults to the last priority with a tooltip reminder to upgrade first, since Blizzard can calculate reforges from stale item stats after upgrades.
+
 ## [1.2.0] - 15 Jun, 2026
 
 ### Added

--- a/Constants.lua
+++ b/Constants.lua
@@ -285,11 +285,11 @@ WSGH.Const.UI = {
       rowHeight = 28,
       rowGap = 4,
       labelGap = 4,
-      rowTopOffset = -44,
+      rowTopOffset = -58,
       rankWidth = 24,
       rankOffsetX = 8,
       labelOffsetX = 8,
-      noteHeight = 18,
+      noteHeight = 32,
       resetButton = { width = 64, height = 20, yOffset = 2 },
       backdrop = {
         tileSize = 16,

--- a/Constants.lua
+++ b/Constants.lua
@@ -174,6 +174,41 @@ WSGH.Const.DEFAULT_TINKERS = {
   [15] = 126392, -- Cloak: Goblin Glider
   [10] = 126731, -- Gloves: Synapse Springs
 }
+
+WSGH.Const.TASK_PRIORITY_TYPES = {
+  {
+    key = "ADD_SOCKET",
+    label = "Add sockets",
+    description = "Socket-addition tasks, usually Blacksmithing sockets; also covers other effects that add a socket.",
+  },
+  {
+    key = "SOCKET_GEM",
+    label = "Socket gems",
+    description = "Gem tasks for empty or wrong sockets.",
+  },
+  {
+    key = "APPLY_ENCHANT",
+    label = "Apply enchants",
+    description = "Standard enchant tasks from the imported plan.",
+  },
+  {
+    key = "APPLY_TINKER",
+    label = "Apply tinkers",
+    description = "Engineering tinker tasks for cloak, gloves, or belt.",
+  },
+  {
+    key = "UPGRADE_ITEM",
+    label = "Upgrade items",
+    description = "Item upgrade tasks using the selected currency preference.",
+  },
+  {
+    key = "REFORGE_ITEM",
+    label = "Reforge items",
+    description = "Reforge tasks from the imported plan.",
+    warning = "Upgrade before reforging to avoid incorrect reforge results.",
+  },
+}
+
 WSGH.Const.HIGHLIGHT = {
   style = "glow",
   color = { 0.95, 0.95, 0.32 },
@@ -241,6 +276,27 @@ WSGH.Const.UI = {
       closeButton = { width = 18, height = 18 },
     },
     categories = { "Gems", "Enchants", "Other" },
+  },
+  settings = {
+    taskPriority = {
+      xOffset = 320,
+      yOffset = -8,
+      width = 250,
+      rowHeight = 28,
+      rowGap = 4,
+      labelGap = 4,
+      rowTopOffset = -44,
+      rankWidth = 24,
+      rankOffsetX = 8,
+      labelOffsetX = 8,
+      noteHeight = 18,
+      resetButton = { width = 64, height = 20, yOffset = 2 },
+      backdrop = {
+        tileSize = 16,
+        edgeSize = 10,
+        inset = 2,
+      },
+    },
   },
   help = {
     iconButton = { width = 18, height = 18 },

--- a/Core.lua
+++ b/Core.lua
@@ -3,7 +3,7 @@ local WSGH = _G.WowSimsGearHelper or {}
 _G.WowSimsGearHelper = WSGH
 
 WSGH.ADDON_NAME = ADDON_NAME
-WSGH.VERSION = "1.2.0"
+WSGH.VERSION = "1.3.0"
 
 local function EnsureDB()
   if type(_G.WowSimsGearHelperDB) ~= "table" then
@@ -37,6 +37,7 @@ local function EnsureDB()
       tinkers = {},
       upgradeCurrency = "JUSTICE",
       useValorForUpgrades = false,
+      taskPriorityOrder = WSGH.Util.GetDefaultTaskPriorityOrder and WSGH.Util.GetDefaultTaskPriorityOrder() or {},
     }
   end
   local prefs = _G.WowSimsGearHelperDB.profile.prefs
@@ -53,6 +54,9 @@ local function EnsureDB()
   if prefs.minimap.hide == nil then prefs.minimap.hide = false end
   if prefs.upgradeCurrency == nil then prefs.upgradeCurrency = "JUSTICE" end
   if prefs.useValorForUpgrades == nil then prefs.useValorForUpgrades = (prefs.upgradeCurrency == "VALOR") end
+  if WSGH.Util.NormalizeTaskPriorityOrder then
+    prefs.taskPriorityOrder = WSGH.Util.NormalizeTaskPriorityOrder(prefs.taskPriorityOrder)
+  end
 
   WSGH.DB = _G.WowSimsGearHelperDB
 end

--- a/Diff/Engine.lua
+++ b/Diff/Engine.lua
@@ -721,6 +721,28 @@ function WSGH.Diff.Engine.Build(plan, equipped, bagIndex)
     end
   end
 
+  local taskPriorityRanks = {}
+  local taskPriorityOrder = WSGH.Util and WSGH.Util.GetTaskPriorityOrder and WSGH.Util.GetTaskPriorityOrder() or {}
+  for index, taskType in ipairs(taskPriorityOrder) do
+    taskPriorityRanks[taskType] = index
+  end
+
+  table.sort(result.tasks, function(a, b)
+    local aRank = taskPriorityRanks[a and a.type] or 999
+    local bRank = taskPriorityRanks[b and b.type] or 999
+    if aRank ~= bRank then
+      return aRank < bRank
+    end
+
+    local aSlot = WSGH.Const.SLOT_INDEX_BY_ID[tonumber(a and a.slotId) or 0] or 999
+    local bSlot = WSGH.Const.SLOT_INDEX_BY_ID[tonumber(b and b.slotId) or 0] or 999
+    if aSlot ~= bSlot then
+      return aSlot < bSlot
+    end
+
+    return (tonumber(a and a.socketIndex) or 0) < (tonumber(b and b.socketIndex) or 0)
+  end)
+
   result.taskCount = #result.tasks
   return result
 end

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 WowSims Gear Helper
 <!-- ![Alpha](https://img.shields.io/badge/alpha-0.1.2--alpha.2-blue) -->
 ![Alpha](https://img.shields.io/badge/alpha-none-lightgrey)
-![Beta](https://img.shields.io/badge/beta-none-lightgrey)
+![Beta](https://img.shields.io/badge/beta-1.3.0--beta.1-blue)
 ![Release](https://img.shields.io/badge/release-1.2.0-success)
 ===================
 

--- a/UI.lua
+++ b/UI.lua
@@ -169,6 +169,7 @@ local HasUpgradeSnapshotChanged
 local BuildDiffAndRender
 local RegisterUIEvents
 local UnregisterUIEvents
+local ExecuteUpgradeAction
 
 local function RuntimePollUpdate(self, elapsed)
   self.pollElapsed = (tonumber(self.pollElapsed) or 0) + (tonumber(elapsed) or 0)
@@ -287,81 +288,129 @@ local function ApplyImportedPlan(plan, source, rawJson)
 end
 WSGH.UI.ApplyImportedPlan = ApplyImportedPlan
 
-local function FindNextPendingSocketTask(rowData)
-  if not rowData then return nil end
-  for _, task in ipairs(rowData.socketTasks or {}) do
-    if task and task.status ~= WSGH.Const.STATUS_OK then
+local function GetTaskPriorityRank(taskType)
+  if WSGH.Util and WSGH.Util.GetTaskPriorityRank then
+    return WSGH.Util.GetTaskPriorityRank(taskType)
+  end
+
+  local order = WSGH.Util and WSGH.Util.NormalizeTaskPriorityOrder and WSGH.Util.NormalizeTaskPriorityOrder(nil) or {}
+  for index, key in ipairs(order) do
+    if key == taskType then
+      return index
+    end
+  end
+  return #order + 1
+end
+
+local function AddPendingActionCandidate(candidates, actionType, task, sequence)
+  candidates[#candidates + 1] = {
+    type = actionType,
+    task = task,
+    rank = GetTaskPriorityRank(actionType),
+    sequence = sequence or (#candidates + 1),
+  }
+end
+
+local function BuildSocketHintTask(rowData)
+  if not (rowData and rowData.socketHintText) then return nil end
+  return {
+    type = "ADD_SOCKET",
+    slotId = rowData.slotId,
+    slotKey = rowData.slotKey,
+    itemId = rowData.equippedItemId or rowData.expectedItemId,
+    status = WSGH.Const.STATUS_WRONG,
+    socketHintText = rowData.socketHintText,
+    socketHintItemId = rowData.socketHintItemId,
+    socketHintExtraItemId = rowData.socketHintExtraItemId,
+    socketHintExtraItemCount = rowData.socketHintExtraItemCount,
+  }
+end
+
+local function FindNextPendingTask(tasks, taskType)
+  for _, task in ipairs(tasks or {}) do
+    local currentType = task and (task.type or taskType)
+    if task and task.status ~= WSGH.Const.STATUS_OK and (not taskType or currentType == taskType) then
       return task
     end
   end
   return nil
 end
 
-local function FindNextPendingEnchantTask(rowData)
-  if not rowData then return nil end
-  for _, task in ipairs(rowData.enchantTasks or {}) do
-    if task and task.status ~= WSGH.Const.STATUS_OK then
-      return task
-    end
-  end
-  return nil
+local function HasPendingTask(tasks, taskType)
+  return FindNextPendingTask(tasks, taskType) ~= nil
 end
 
-local function HasPendingUpgradeTask(rowData)
-  if not rowData then return false end
-  for _, task in ipairs(rowData.upgradeTasks or {}) do
-    if task and task.status ~= WSGH.Const.STATUS_OK then
-      return true
-    end
-  end
-  return false
-end
+function WSGH.UI.GetNextPriorityAction(rowData)
+  if not rowData or rowData.rowStatus ~= "NEEDS_WORK" then return nil end
 
-local function HasPendingReforgeTask(rowData)
-  if not rowData then return false end
-  for _, task in ipairs(rowData.reforgeTasks or {}) do
-    if task and task.status ~= WSGH.Const.STATUS_OK then
-      return true
-    end
+  local candidates = {}
+  local sequence = 0
+
+  local addSocketTask = BuildSocketHintTask(rowData)
+  if addSocketTask then
+    sequence = sequence + 1
+    AddPendingActionCandidate(candidates, "ADD_SOCKET", addSocketTask, sequence)
   end
-  return false
+
+  local socketTask = FindNextPendingTask(rowData.socketTasks, "SOCKET_GEM")
+  if socketTask then
+    sequence = sequence + 1
+    AddPendingActionCandidate(candidates, "SOCKET_GEM", socketTask, sequence)
+  end
+
+  local enchantTask = FindNextPendingTask(rowData.enchantTasks, "APPLY_ENCHANT")
+  if enchantTask then
+    sequence = sequence + 1
+    AddPendingActionCandidate(candidates, "APPLY_ENCHANT", enchantTask, sequence)
+  end
+
+  local tinkerTask = FindNextPendingTask(rowData.enchantTasks, "APPLY_TINKER")
+  if tinkerTask then
+    sequence = sequence + 1
+    AddPendingActionCandidate(candidates, "APPLY_TINKER", tinkerTask, sequence)
+  end
+
+  local upgradeTask = FindNextPendingTask(rowData.upgradeTasks, "UPGRADE_ITEM")
+  if upgradeTask then
+    sequence = sequence + 1
+    AddPendingActionCandidate(candidates, "UPGRADE_ITEM", upgradeTask, sequence)
+  end
+
+  local reforgeTask = FindNextPendingTask(rowData.reforgeTasks, "REFORGE_ITEM")
+  if reforgeTask then
+    sequence = sequence + 1
+    AddPendingActionCandidate(candidates, "REFORGE_ITEM", reforgeTask, sequence)
+  end
+
+  table.sort(candidates, function(a, b)
+    if a.rank ~= b.rank then
+      return a.rank < b.rank
+    end
+    return a.sequence < b.sequence
+  end)
+
+  return candidates[1]
 end
 
 function WSGH.UI.GetRowActionPriority(rowData)
-  local nextSocketTask = FindNextPendingSocketTask(rowData)
-  local nextEnchantTask = FindNextPendingEnchantTask(rowData)
+  local nextSocketTask = FindNextPendingTask(rowData and rowData.socketTasks or nil, "SOCKET_GEM")
+  local nextEnchantTask = FindNextPendingTask(rowData and rowData.enchantTasks or nil, "APPLY_ENCHANT")
+    or FindNextPendingTask(rowData and rowData.enchantTasks or nil, "APPLY_TINKER")
   return {
+    nextAction = WSGH.UI.GetNextPriorityAction(rowData),
     nextSocketTask = nextSocketTask,
     nextEnchantTask = nextEnchantTask,
+    hasAddSocketWork = rowData and rowData.socketHintText ~= nil or false,
     hasSocketWork = nextSocketTask ~= nil,
-    hasEnchantWork = nextEnchantTask ~= nil,
-    hasUpgradeWork = HasPendingUpgradeTask(rowData),
-    hasReforgeWork = HasPendingReforgeTask(rowData),
+    hasEnchantWork = HasPendingTask(rowData and rowData.enchantTasks or nil, "APPLY_ENCHANT")
+      or HasPendingTask(rowData and rowData.enchantTasks or nil, "APPLY_TINKER"),
+    hasUpgradeWork = HasPendingTask(rowData and rowData.upgradeTasks or nil, "UPGRADE_ITEM"),
+    hasReforgeWork = HasPendingTask(rowData and rowData.reforgeTasks or nil, "REFORGE_ITEM"),
   }
 end
 
 local function DetermineNextAction(rowData)
-  if not rowData or rowData.rowStatus ~= "NEEDS_WORK" then return nil end
-  local priority = WSGH.UI.GetRowActionPriority(rowData)
-  if priority.nextSocketTask then
-    return {
-      type = "SOCKET_GEM",
-      task = priority.nextSocketTask,
-    }
-  end
-  if priority.nextEnchantTask then
-    return {
-      type = priority.nextEnchantTask.type or "APPLY_ENCHANT",
-      task = priority.nextEnchantTask,
-    }
-  end
-  if priority.hasReforgeWork and not priority.hasUpgradeWork then
-    return {
-      type = "REFORGE_ITEM",
-      task = rowData.reforgeTasks and rowData.reforgeTasks[1] or nil,
-    }
-  end
-  return nil
+  return WSGH.UI.GetNextPriorityAction(rowData)
 end
 
 local function GetRowBySlotId(slotId)
@@ -1124,7 +1173,10 @@ end
 
 local function ExecuteAction(action, rowData)
   if not action then return end
-  if action.type == "SOCKET_GEM" then
+  if action.type == "ADD_SOCKET" then
+    Guide.currentAction = nil
+    ExecuteSocketHintAction(rowData)
+  elseif action.type == "SOCKET_GEM" then
     if action.task and action.task.status == WSGH.Const.STATUS_MISSING then
       WSGH.Util.Print(("Missing required gem (%d) for %s."):format(action.task.wantGemId, rowData and rowData.slotKey or "slot"))
     end
@@ -1139,6 +1191,11 @@ local function ExecuteAction(action, rowData)
     end
     Guide.currentAction = action
     ExecuteEnchantAction(action)
+  elseif action.type == "UPGRADE_ITEM" then
+    Guide.currentAction = nil
+    if ExecuteUpgradeAction then
+      ExecuteUpgradeAction(rowData)
+    end
   elseif action.type == "REFORGE_ITEM" then
     Guide.currentAction = action
     ExecuteReforgeAction()
@@ -1674,46 +1731,24 @@ local function TryInsertEquippedItemIntoItemUpgradeFrame(slotId)
   return consumed
 end
 
-local function OnRowAction(rowData)
+ExecuteUpgradeAction = function(rowData)
+  ClearActionGuidanceHighlights()
   if not rowData then return end
-  if rowData.rowStatus == "WRONG_ITEM" then
-    ClearActionGuidanceHighlights()
-    EquipExpectedItem(rowData)
-    return
+
+  local itemName = GetItemInfo(rowData.expectedItemId or 0) or rowData.slotKey or "item"
+  local current = tonumber(rowData.equippedUpgradeLevel) or 0
+  local target = tonumber(rowData.expectedUpgradeStep) or 0
+  local maxStep = tonumber(rowData.equippedUpgradeMax) or 0
+  if maxStep <= 0 then
+    maxStep = math.max(2, target)
   end
-  if rowData.socketHintText then
-    if InCombatLockdown and InCombatLockdown() then
-      WSGH.Util.Print("Cannot start guidance during combat; try again after combat.")
-      return
-    end
-    ExecuteSocketHintAction(rowData)
-    return
+  if target > maxStep then
+    target = maxStep
   end
-  local priority = WSGH.UI.GetRowActionPriority(rowData)
-  if priority.hasUpgradeWork and not priority.hasSocketWork and not priority.hasEnchantWork then
-    ClearActionGuidanceHighlights()
-    local itemName = GetItemInfo(rowData.expectedItemId or 0) or rowData.slotKey or "item"
-    local current = tonumber(rowData.equippedUpgradeLevel) or 0
-    local target = tonumber(rowData.expectedUpgradeStep) or 0
-    local maxStep = tonumber(rowData.equippedUpgradeMax) or 0
-    if maxStep <= 0 then
-      maxStep = math.max(2, target)
-    end
-    if target > maxStep then
-      target = maxStep
-    end
-    local inserted = TryInsertEquippedItemIntoItemUpgradeFrame(rowData.slotId)
-    if inserted then
-      WSGH.Util.Print(("Inserted %s into the upgrader (%d/%d -> %d/%d)."):format(
-        tostring(itemName),
-        current,
-        maxStep,
-        target,
-        maxStep
-      ))
-      return
-    end
-    WSGH.Util.Print(("Upgrade needed for %s: %d/%d -> %d/%d. Visit the Item Upgrader NPC."):format(
+
+  local inserted = TryInsertEquippedItemIntoItemUpgradeFrame(rowData.slotId)
+  if inserted then
+    WSGH.Util.Print(("Inserted %s into the upgrader (%d/%d -> %d/%d)."):format(
       tostring(itemName),
       current,
       maxStep,
@@ -1722,8 +1757,21 @@ local function OnRowAction(rowData)
     ))
     return
   end
-  if priority.hasReforgeWork and not priority.hasSocketWork and not priority.hasEnchantWork and not priority.hasUpgradeWork then
-    ExecuteReforgeAction()
+
+  WSGH.Util.Print(("Upgrade needed for %s: %d/%d -> %d/%d. Visit the Item Upgrader NPC."):format(
+    tostring(itemName),
+    current,
+    maxStep,
+    target,
+    maxStep
+  ))
+end
+
+local function OnRowAction(rowData)
+  if not rowData then return end
+  if rowData.rowStatus == "WRONG_ITEM" then
+    ClearActionGuidanceHighlights()
+    EquipExpectedItem(rowData)
     return
   end
   Guide.StartForRow(rowData)

--- a/UI/Rows.lua
+++ b/UI/Rows.lua
@@ -323,6 +323,15 @@ end
 
 local function AddRowTaskTooltipLines(rowData, tooltipState)
   local added = false
+  local taskCategories = {}
+  local categorySequence = 0
+
+  local function getTaskPriorityRank(taskType)
+    if WSGH.Util and WSGH.Util.GetTaskPriorityRank then
+      return WSGH.Util.GetTaskPriorityRank(taskType)
+    end
+    return 999
+  end
 
   local function socketLabel(socketIndex)
     socketIndex = tonumber(socketIndex) or 0
@@ -344,6 +353,31 @@ local function AddRowTaskTooltipLines(rowData, tooltipState)
     end
   end
 
+  local function addTaskCategory(taskType, title, lines)
+    if type(lines) ~= "table" or #lines == 0 then return end
+    categorySequence = categorySequence + 1
+    taskCategories[#taskCategories + 1] = {
+      taskType = taskType,
+      title = title,
+      lines = lines,
+      rank = getTaskPriorityRank(taskType),
+      sequence = categorySequence,
+    }
+  end
+
+  local function renderTaskCategories()
+    table.sort(taskCategories, function(a, b)
+      if a.rank ~= b.rank then
+        return a.rank < b.rank
+      end
+      return a.sequence < b.sequence
+    end)
+
+    for _, category in ipairs(taskCategories) do
+      addCategory(category.title, category.lines)
+    end
+  end
+
   local function addSocketGroup(title, sockets, r, g, b)
     if #sockets == 0 then return end
     sortSockets(sockets)
@@ -351,7 +385,7 @@ local function AddRowTaskTooltipLines(rowData, tooltipState)
     for _, socketIndex in ipairs(sockets) do
       lines[#lines + 1] = { text = socketLabel(socketIndex), r = r, g = g, b = b }
     end
-    addCategory(title, lines)
+    addTaskCategory("SOCKET_GEM", title, lines)
   end
 
   if not rowData then return false end
@@ -365,7 +399,7 @@ local function AddRowTaskTooltipLines(rowData, tooltipState)
   end
 
   if rowData.socketHintText then
-    addCategory("Socket", { SocketHintDescription(rowData) })
+    addTaskCategory("ADD_SOCKET", "Add socket", { SocketHintDescription(rowData) })
   end
 
   local missingGemSockets = {}
@@ -390,14 +424,22 @@ local function AddRowTaskTooltipLines(rowData, tooltipState)
   end
   addSocketGroup("Missing gems", missingGemSockets)
   addSocketGroup("Insert gems", insertGemSockets)
-  addSocketGroup("Add extra socket before gem", deferredGemSockets)
+  if #deferredGemSockets > 0 then
+    sortSockets(deferredGemSockets)
+    local deferredLines = {}
+    for _, socketIndex in ipairs(deferredGemSockets) do
+      deferredLines[#deferredLines + 1] = { text = socketLabel(socketIndex) }
+    end
+    addTaskCategory("ADD_SOCKET", "Add extra socket before gem", deferredLines)
+  end
 
   local enchantLines = {}
+  local tinkerLines = {}
   for _, task in ipairs(rowData.enchantTasks or {}) do
     if task.status ~= WSGH.Const.STATUS_OK then
       local spellName = GetSpellName(task.wantEnchantId, "enchant") or "expected enchant"
       if task.type == "APPLY_TINKER" then
-        enchantLines[#enchantLines + 1] = "Apply tinker: " .. spellName .. "."
+        tinkerLines[#tinkerLines + 1] = "Apply tinker: " .. spellName .. "."
       elseif task.status == WSGH.Const.STATUS_MISSING then
         local itemName = GetItemName(task.wantEnchantItemId, "item") or "required enchant item"
         enchantLines[#enchantLines + 1] = "Missing enchant item: " .. itemName .. "."
@@ -408,7 +450,8 @@ local function AddRowTaskTooltipLines(rowData, tooltipState)
       end
     end
   end
-  addCategory("Enchanting", enchantLines)
+  addTaskCategory("APPLY_ENCHANT", "Enchanting", enchantLines)
+  addTaskCategory("APPLY_TINKER", "Tinkers", tinkerLines)
 
   local pendingUpgradeCount = 0
   local firstUpgradeTask = nil
@@ -423,7 +466,7 @@ local function AddRowTaskTooltipLines(rowData, tooltipState)
     local targetStep = tonumber(firstUpgradeTask and firstUpgradeTask.targetUpgradeStep) or tonumber(rowData.expectedUpgradeStep) or 0
     local maxStep = tonumber(rowData.equippedUpgradeMax) or tonumber(firstUpgradeTask and firstUpgradeTask.upgradeMax) or 0
     if maxStep <= 0 then maxStep = math.max(2, targetStep) end
-    addCategory("Upgrades", { ("Upgrade item: %d/%d -> %d/%d."):format(currentStep, maxStep, targetStep, maxStep) })
+    addTaskCategory("UPGRADE_ITEM", "Upgrades", { ("Upgrade item: %d/%d -> %d/%d."):format(currentStep, maxStep, targetStep, maxStep) })
   end
 
   local reforgeLines = {}
@@ -452,7 +495,8 @@ local function AddRowTaskTooltipLines(rowData, tooltipState)
   if not hasReforgeLite and rowData.reforgeTasks and #rowData.reforgeTasks > 0 then
     reforgeLines[#reforgeLines + 1] = "ReforgeLite Classic is recommended for this task."
   end
-  addCategory("Reforging", reforgeLines)
+  addTaskCategory("REFORGE_ITEM", "Reforging", reforgeLines)
+  renderTaskCategories()
 
   return added
 end
@@ -691,6 +735,7 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
   local hasPriorityAnyEnchant = priority and priority.hasEnchantWork or (hasEnchantWork or hasTinkerWork)
   local hasPriorityUpgrade = priority and priority.hasUpgradeWork or hasUpgradeWork
   local hasPriorityReforge = priority and priority.hasReforgeWork or hasReforgeWork
+  local nextPriorityAction = priority and priority.nextAction or nil
   local nextPriorityEnchantTask = priority and priority.nextEnchantTask or nil
 
   if rowData.rowStatus == "WRONG_ITEM" then
@@ -953,31 +998,7 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
   end)
   SetActionButtonReforgeStyle(rowFrame.action, false)
 
-  if rowData.socketHintText then
-    rowFrame.action:SetText("Add socket")
-    local hintItemId = tonumber(rowData.socketHintItemId) or 0
-    local extraItemId = tonumber(rowData.socketHintExtraItemId) or 0
-    local missingHintItem = hintItemId ~= 0 and not HasItemInBags(hintItemId)
-    local missingExtraItem = extraItemId ~= 0 and not HasItemInBags(extraItemId)
-    if missingHintItem or missingExtraItem then
-      rowFrame.action:SetEnabled(false)
-      rowFrame.action:SetText("Purchase")
-      rowFrame.action:SetScript("OnEnter", function(self)
-        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-        GameTooltip:SetText("Purchase required items first.")
-        GameTooltip:Show()
-      end)
-      rowFrame.action:SetScript("OnLeave", GameTooltip_Hide)
-    else
-      rowFrame.action:SetEnabled(true)
-      rowFrame.action:SetScript("OnEnter", function(self)
-        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-        GameTooltip:SetText(SocketHintDescription(rowData), nil, nil, nil, nil, true)
-        GameTooltip:Show()
-      end)
-      rowFrame.action:SetScript("OnLeave", GameTooltip_Hide)
-    end
-  elseif rowData.rowStatus == "OK" then
+  if rowData.rowStatus == "OK" then
     rowFrame.action:SetEnabled(false)
     rowFrame.action:SetText("Done")
   elseif rowData.rowStatus == "WRONG_ITEM" then
@@ -1004,7 +1025,19 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
         end
       end
     end
-    if hasBlockingTask then
+    local nextActionType = nextPriorityAction and nextPriorityAction.type or nil
+    local nextActionTask = nextPriorityAction and nextPriorityAction.task or nil
+    local isNextActionMissing = false
+    if nextActionType == "ADD_SOCKET" then
+      local hintItemId = tonumber(rowData.socketHintItemId) or 0
+      local extraItemId = tonumber(rowData.socketHintExtraItemId) or 0
+      isNextActionMissing = (hintItemId ~= 0 and not HasItemInBags(hintItemId))
+        or (extraItemId ~= 0 and not HasItemInBags(extraItemId))
+    elseif nextActionTask and nextActionTask.status == WSGH.Const.STATUS_MISSING then
+      isNextActionMissing = true
+    end
+
+    if isNextActionMissing or (not nextPriorityAction and hasBlockingTask) then
       rowFrame.action:SetEnabled(false)
       rowFrame.action:SetText("Purchase")
       rowFrame.action:SetScript("OnEnter", function(self)
@@ -1013,15 +1046,26 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
         GameTooltip:Show()
       end)
       rowFrame.action:SetScript("OnLeave", GameTooltip_Hide)
-    elseif hasPrioritySocket then
+    elseif nextActionType == "ADD_SOCKET" then
+      rowFrame.action:SetEnabled(true)
+      rowFrame.action:SetText("Add socket")
+      rowFrame.action:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:SetText(SocketHintDescription(rowData), nil, nil, nil, nil, true)
+        GameTooltip:Show()
+      end)
+      rowFrame.action:SetScript("OnLeave", GameTooltip_Hide)
+    elseif nextActionType == "SOCKET_GEM" or (not nextActionType and hasPrioritySocket) then
       rowFrame.action:SetEnabled(true)
       rowFrame.action:SetText("Socket")
       rowFrame.action:SetScript("OnEnter", nil)
       rowFrame.action:SetScript("OnLeave", nil)
-    elseif hasPriorityAnyEnchant and not hasPrioritySocket then
+    elseif nextActionType == "APPLY_ENCHANT" or nextActionType == "APPLY_TINKER"
+      or (not nextActionType and hasPriorityAnyEnchant and not hasPrioritySocket) then
       rowFrame.action:SetEnabled(true)
-      local nextIsTinker = nextPriorityEnchantTask and nextPriorityEnchantTask.type == "APPLY_TINKER"
-      local nextManual = nextPriorityEnchantTask and nextPriorityEnchantTask.manualOnly == true
+      local enchantActionTask = nextActionTask or nextPriorityEnchantTask
+      local nextIsTinker = nextActionType == "APPLY_TINKER" or (enchantActionTask and enchantActionTask.type == "APPLY_TINKER")
+      local nextManual = enchantActionTask and enchantActionTask.manualOnly == true
       rowFrame.action:SetText(nextIsTinker and "Tinker" or "Enchant")
       rowFrame.action:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
@@ -1037,13 +1081,13 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
         GameTooltip:Show()
       end)
       rowFrame.action:SetScript("OnLeave", GameTooltip_Hide)
-    elseif hasPriorityUpgrade and not hasPriorityAnyEnchant then
+    elseif nextActionType == "UPGRADE_ITEM" or (not nextActionType and hasPriorityUpgrade and not hasPriorityAnyEnchant) then
       rowFrame.action:SetEnabled(true)
       rowFrame.action:SetText("Upgrade")
       rowFrame.action:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         local expected = tonumber(rowData.expectedUpgradeStep) or 0
-        local firstTask = rowData.upgradeTasks and rowData.upgradeTasks[1] or nil
+        local firstTask = nextActionTask or (rowData.upgradeTasks and rowData.upgradeTasks[1] or nil)
         local targetStep = firstTask and tonumber(firstTask.targetUpgradeStep) or expected
         local currentStep = tonumber(rowData.equippedUpgradeLevel) or 0
         local maxStep = tonumber(rowData.equippedUpgradeMax) or 0
@@ -1053,11 +1097,11 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
         GameTooltip:Show()
       end)
       rowFrame.action:SetScript("OnLeave", GameTooltip_Hide)
-    elseif hasPriorityReforge and not hasPriorityAnyEnchant and not hasPriorityUpgrade then
+    elseif nextActionType == "REFORGE_ITEM" or (not nextActionType and hasPriorityReforge and not hasPriorityAnyEnchant and not hasPriorityUpgrade) then
       rowFrame.action:SetEnabled(true)
       rowFrame.action:SetText("Reforge*")
       SetActionButtonReforgeStyle(rowFrame.action, true)
-      local firstReforgeTask = rowData.reforgeTasks and rowData.reforgeTasks[1] or nil
+      local firstReforgeTask = nextActionTask or (rowData.reforgeTasks and rowData.reforgeTasks[1] or nil)
       local reforgeText = firstReforgeTask and firstReforgeTask.wantReforgeText or nil
       local reforgeLiteIntegration = WSGH.Integrations and WSGH.Integrations.ReforgeLite or nil
       local hasReforgeLite = reforgeLiteIntegration
@@ -1071,6 +1115,7 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
         else
           GameTooltip:AddLine("Apply reforge manually. ReforgeLite Classic is recommended for this step.", 1, 0.82, 0.2, true)
         end
+        GameTooltip:AddLine("Upgrade before reforging to avoid incorrect reforge results.", 1, 0.82, 0.2, true)
         GameTooltip:Show()
       end)
       rowFrame.action:SetScript("OnLeave", GameTooltip_Hide)

--- a/UI/Settings.lua
+++ b/UI/Settings.lua
@@ -11,6 +11,321 @@ local function GetPreferences()
   return WSGH.Util and WSGH.Util.GetPreferences and WSGH.Util.GetPreferences() or nil
 end
 
+local function CreateTaskTypeLookup()
+  local lookup = {}
+  for _, taskType in ipairs(WSGH.Const and WSGH.Const.TASK_PRIORITY_TYPES or {}) do
+    if type(taskType.key) == "string" and taskType.key ~= "" then
+      lookup[taskType.key] = taskType
+    end
+  end
+  return lookup
+end
+
+local function NormalizeTaskPriorityOrder(order)
+  if WSGH.Util and WSGH.Util.NormalizeTaskPriorityOrder then
+    return WSGH.Util.NormalizeTaskPriorityOrder(order)
+  end
+
+  local normalized = {}
+  for _, taskType in ipairs(WSGH.Const and WSGH.Const.TASK_PRIORITY_TYPES or {}) do
+    if type(taskType.key) == "string" and taskType.key ~= "" then
+      normalized[#normalized + 1] = taskType.key
+    end
+  end
+  return normalized
+end
+
+local function FindTaskPriorityIndex(order, key)
+  for index, orderKey in ipairs(order or {}) do
+    if orderKey == key then
+      return index
+    end
+  end
+  return nil
+end
+
+local function CreateTaskPrioritySection(parent, anchor)
+  local layout = WSGH.Const
+    and WSGH.Const.UI
+    and WSGH.Const.UI.settings
+    and WSGH.Const.UI.settings.taskPriority
+    or {}
+  local width = tonumber(layout.width) or 250
+  local rowHeight = tonumber(layout.rowHeight) or 28
+  local rowGap = tonumber(layout.rowGap) or 4
+  local labelGap = tonumber(layout.labelGap) or 4
+  local rowTopOffset = tonumber(layout.rowTopOffset) or -44
+  local rankWidth = tonumber(layout.rankWidth) or 24
+  local rankOffsetX = tonumber(layout.rankOffsetX) or 8
+  local labelOffsetX = tonumber(layout.labelOffsetX) or 2
+  local resetButton = layout.resetButton or {}
+  local backdrop = layout.backdrop or {}
+  local backdropInset = tonumber(backdrop.inset) or 2
+  local taskTypes = WSGH.Const and WSGH.Const.TASK_PRIORITY_TYPES or {}
+
+  local section = CreateFrame("Frame", nil, parent)
+  section:SetPoint(
+    "TOPLEFT",
+    anchor,
+    "TOPLEFT",
+    tonumber(layout.xOffset) or 300,
+    tonumber(layout.yOffset) or -8
+  )
+  section:SetSize(width, math.abs(rowTopOffset) + (#taskTypes * (rowHeight + rowGap)))
+
+  local title = section:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+  title:SetPoint("TOPLEFT", section, "TOPLEFT", 0, 0)
+  title:SetText("Task priority")
+
+  local reset = CreateFrame("Button", nil, section, "UIPanelButtonTemplate")
+  reset:SetSize(tonumber(resetButton.width) or 64, tonumber(resetButton.height) or 20)
+  reset:SetPoint("TOPRIGHT", section, "TOPRIGHT", 0, tonumber(resetButton.yOffset) or 2)
+  reset:SetText("Reset")
+
+  local note = section:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+  note:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -labelGap)
+  note:SetPoint("RIGHT", section, "RIGHT", 0, 0)
+  note:SetHeight(tonumber(layout.noteHeight) or 28)
+  note:SetJustifyH("LEFT")
+  note:SetWordWrap(true)
+  note:SetText("Drag rows to set the task order.")
+
+  local taskTypeLookup = CreateTaskTypeLookup()
+  local rows = {}
+  local draggingKey = nil
+  local dragHoverIndex = nil
+  local dragInsertIndex = nil
+
+  local function GetStoredOrder()
+    local preferencesTable = GetPreferences()
+    if not preferencesTable then
+      return NormalizeTaskPriorityOrder(nil)
+    end
+
+    preferencesTable.taskPriorityOrder = NormalizeTaskPriorityOrder(preferencesTable.taskPriorityOrder)
+    return preferencesTable.taskPriorityOrder
+  end
+
+  local function SetStoredOrder(order)
+    local preferencesTable = GetPreferences()
+    if not preferencesTable then return end
+    preferencesTable.taskPriorityOrder = NormalizeTaskPriorityOrder(order)
+  end
+
+  local function MoveTaskToIndex(taskKey, targetIndex)
+    if not taskKey or not targetIndex then return false end
+
+    local order = NormalizeTaskPriorityOrder(GetStoredOrder())
+    local currentIndex = FindTaskPriorityIndex(order, taskKey)
+    if not currentIndex or currentIndex == targetIndex then return false end
+
+    table.remove(order, currentIndex)
+    if currentIndex < targetIndex then
+      targetIndex = targetIndex - 1
+    end
+    targetIndex = math.max(1, math.min(targetIndex, #order + 1))
+    if currentIndex == targetIndex then return false end
+
+    table.insert(order, targetIndex, taskKey)
+    SetStoredOrder(order)
+    return true
+  end
+
+  local RefreshRows
+  local StopDrag
+
+  local function GetCursorCanvasY()
+    if not GetCursorPosition then return nil end
+
+    local _, cursorY = GetCursorPosition()
+    local scale = 1
+    if UIParent and UIParent.GetEffectiveScale then
+      scale = UIParent:GetEffectiveScale() or 1
+    end
+    return cursorY and (cursorY / scale) or nil
+  end
+
+  local function GetInsertionIndexForRow(row)
+    if not row then return nil end
+
+    local targetIndex = row.orderIndex
+    local cursorY = GetCursorCanvasY()
+    local top = row.GetTop and row:GetTop() or nil
+    local bottom = row.GetBottom and row:GetBottom() or nil
+    if cursorY and top and bottom then
+      local midpoint = bottom + ((top - bottom) / 2)
+      if cursorY < midpoint then
+        targetIndex = targetIndex + 1
+      end
+    end
+    return targetIndex
+  end
+
+  local function GetMouseOverRow()
+    for _, row in ipairs(rows) do
+      if row:IsShown() and row.IsMouseOver and row:IsMouseOver() then
+        return row
+      end
+    end
+    return nil
+  end
+
+  local function UpdateDrag()
+    if not draggingKey then return end
+
+    if not IsMouseButtonDown or not IsMouseButtonDown("LeftButton") then
+      StopDrag()
+      return
+    end
+
+    local row = GetMouseOverRow()
+    local nextHoverIndex = row and row.orderIndex or nil
+    local nextInsertIndex = row and GetInsertionIndexForRow(row) or nil
+    local shouldRefresh = nextHoverIndex ~= dragHoverIndex or nextInsertIndex ~= dragInsertIndex
+    dragHoverIndex = nextHoverIndex
+    dragInsertIndex = nextInsertIndex
+
+    if row and row.taskKey ~= draggingKey and nextInsertIndex then
+      shouldRefresh = MoveTaskToIndex(draggingKey, nextInsertIndex) or shouldRefresh
+    end
+
+    if shouldRefresh and RefreshRows then
+      RefreshRows()
+    end
+  end
+
+  StopDrag = function()
+    if not draggingKey then return end
+
+    draggingKey = nil
+    dragHoverIndex = nil
+    dragInsertIndex = nil
+    section:SetScript("OnUpdate", nil)
+    if RefreshRows then RefreshRows() end
+  end
+
+  local function StartDrag(row)
+    draggingKey = row.taskKey
+    dragHoverIndex = row.orderIndex
+    dragInsertIndex = row.orderIndex
+    section:SetScript("OnUpdate", UpdateDrag)
+    if RefreshRows then RefreshRows() end
+  end
+
+  RefreshRows = function()
+    local order = GetStoredOrder()
+    for index, key in ipairs(order) do
+      local row = rows[index]
+      local taskType = taskTypeLookup[key] or { label = key, description = "" }
+
+      if row then
+        row.taskKey = key
+        row.orderIndex = index
+        row:ClearAllPoints()
+        row:SetPoint("TOPLEFT", section, "TOPLEFT", 0, rowTopOffset - ((index - 1) * (rowHeight + rowGap)))
+        row:SetPoint("RIGHT", section, "RIGHT", 0, 0)
+        row:SetHeight(rowHeight)
+        row.rank:SetText(tostring(index))
+        row.label:SetText(taskType.label or key)
+
+        if draggingKey == key then
+          row:SetBackdropColor(0.2, 0.32, 0.42, 0.85)
+          row:SetBackdropBorderColor(0.95, 0.85, 0.25, 1)
+        else
+          row:SetBackdropColor(0.03, 0.03, 0.03, 0.45)
+          row:SetBackdropBorderColor(0.35, 0.35, 0.35, 1)
+        end
+
+        row:Show()
+      end
+    end
+
+    for index = #order + 1, #rows do
+      rows[index]:Hide()
+    end
+  end
+
+  for index = 1, #taskTypes do
+    local row = CreateFrame("Button", nil, section, "BackdropTemplate")
+    row:SetSize(width, rowHeight)
+    row:SetBackdrop({
+      bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+      edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+      tile = true,
+      tileSize = tonumber(backdrop.tileSize) or 16,
+      edgeSize = tonumber(backdrop.edgeSize) or 10,
+      insets = { left = backdropInset, right = backdropInset, top = backdropInset, bottom = backdropInset },
+    })
+    row:EnableMouse(true)
+
+    row.rank = row:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+    row.rank:SetPoint("LEFT", row, "LEFT", rankOffsetX, 0)
+    row.rank:SetWidth(rankWidth)
+    row.rank:SetJustifyH("LEFT")
+
+    row.label = row:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    row.label:SetPoint("LEFT", row.rank, "RIGHT", labelOffsetX, 0)
+    row.label:SetPoint("RIGHT", row, "RIGHT", -rankOffsetX, 0)
+    row.label:SetJustifyH("LEFT")
+    row.label:SetWordWrap(false)
+
+    row:SetScript("OnMouseDown", function(self, button)
+      if button == "LeftButton" then
+        StartDrag(self)
+      end
+    end)
+    row:SetScript("OnMouseUp", function()
+      StopDrag()
+    end)
+    row:SetScript("OnEnter", function(self)
+      if RefreshRows then RefreshRows() end
+      local taskType = taskTypeLookup[self.taskKey] or {}
+      GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+      GameTooltip:SetText(taskType.label or tostring(self.taskKey or "Task"), 1, 1, 1)
+      if type(taskType.description) == "string" and taskType.description ~= "" then
+        GameTooltip:AddLine(taskType.description, nil, nil, nil, true)
+      end
+      if type(taskType.warning) == "string" and taskType.warning ~= "" then
+        GameTooltip:AddLine(taskType.warning, 1, 0.82, 0.2, true)
+      end
+      GameTooltip:AddLine("Drag rows up or down to reorder.", 0.8, 0.8, 0.8, true)
+      GameTooltip:Show()
+    end)
+    row:SetScript("OnLeave", function()
+      if RefreshRows then RefreshRows() end
+      GameTooltip_Hide()
+    end)
+
+    rows[index] = row
+  end
+
+  reset:SetScript("OnClick", function()
+    if WSGH.Util and WSGH.Util.GetDefaultTaskPriorityOrder then
+      SetStoredOrder(WSGH.Util.GetDefaultTaskPriorityOrder())
+    else
+      SetStoredOrder(nil)
+    end
+    RefreshRows()
+  end)
+  reset:SetScript("OnEnter", function(self)
+    GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+    GameTooltip:SetText("Reset task priority", 1, 1, 1)
+    GameTooltip:AddLine("Restore the default task type order.", nil, nil, nil, true)
+    GameTooltip:Show()
+  end)
+  reset:SetScript("OnLeave", GameTooltip_Hide)
+
+  section:SetScript("OnHide", function()
+    draggingKey = nil
+    dragHoverIndex = nil
+    dragInsertIndex = nil
+    section:SetScript("OnUpdate", nil)
+  end)
+
+  RefreshRows()
+  return section
+end
+
 local function BuildOptionsPanel()
   if optionsPanel then return end
 
@@ -32,6 +347,7 @@ local function BuildOptionsPanel()
   versionText:SetText(("Version: %s"):format(tostring(addonVersion)))
 
   local preferences = GetPreferences() or {}
+  CreateTaskPrioritySection(optionsPanel, versionText)
 
   local persistCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
   persistCheck:SetPoint("TOPLEFT", versionText, "BOTTOMLEFT", 0, -8)

--- a/UI/Settings.lua
+++ b/UI/Settings.lua
@@ -88,7 +88,7 @@ local function CreateTaskPrioritySection(parent, anchor)
   note:SetHeight(tonumber(layout.noteHeight) or 28)
   note:SetJustifyH("LEFT")
   note:SetWordWrap(true)
-  note:SetText("Drag rows to set the task order.")
+  note:SetText("Drag rows to set the task order.\nIf the window is already open, you'll need to reopen it to see the changes.")
 
   local taskTypeLookup = CreateTaskTypeLookup()
   local rows = {}

--- a/Util.lua
+++ b/Util.lua
@@ -53,6 +53,46 @@ function WSGH.Util.ArrayFilterNonZero(arr)
   return out
 end
 
+function WSGH.Util.GetDefaultTaskPriorityOrder()
+  local order = {}
+  for _, taskType in ipairs(WSGH.Const and WSGH.Const.TASK_PRIORITY_TYPES or {}) do
+    if type(taskType.key) == "string" and taskType.key ~= "" then
+      order[#order + 1] = taskType.key
+    end
+  end
+  return order
+end
+
+function WSGH.Util.NormalizeTaskPriorityOrder(order)
+  local normalized = {}
+  local seen = {}
+  local valid = {}
+
+  for _, taskType in ipairs(WSGH.Const and WSGH.Const.TASK_PRIORITY_TYPES or {}) do
+    if type(taskType.key) == "string" and taskType.key ~= "" then
+      valid[taskType.key] = true
+    end
+  end
+
+  if type(order) == "table" then
+    for _, key in ipairs(order) do
+      if valid[key] and not seen[key] then
+        normalized[#normalized + 1] = key
+        seen[key] = true
+      end
+    end
+  end
+
+  for _, key in ipairs(WSGH.Util.GetDefaultTaskPriorityOrder()) do
+    if not seen[key] then
+      normalized[#normalized + 1] = key
+      seen[key] = true
+    end
+  end
+
+  return normalized
+end
+
 function WSGH.Util.Print(msg)
   DEFAULT_CHAT_FRAME:AddMessage(("|cff33ff99WSGH|r: %s"):format(tostring(msg)))
 end
@@ -149,6 +189,7 @@ function WSGH.Util.GetPreferences()
   if prefs.useValorForUpgrades == nil then
     prefs.useValorForUpgrades = (prefs.upgradeCurrency == "VALOR")
   end
+  prefs.taskPriorityOrder = WSGH.Util.NormalizeTaskPriorityOrder(prefs.taskPriorityOrder)
   WSGH.DB = _G.WowSimsGearHelperDB
   return prefs
 end

--- a/Util.lua
+++ b/Util.lua
@@ -93,6 +93,21 @@ function WSGH.Util.NormalizeTaskPriorityOrder(order)
   return normalized
 end
 
+function WSGH.Util.GetTaskPriorityOrder()
+  local preferences = WSGH.Util.GetPreferences and WSGH.Util.GetPreferences() or nil
+  return WSGH.Util.NormalizeTaskPriorityOrder(preferences and preferences.taskPriorityOrder or nil)
+end
+
+function WSGH.Util.GetTaskPriorityRank(taskType)
+  local order = WSGH.Util.GetTaskPriorityOrder()
+  for index, key in ipairs(order) do
+    if key == taskType then
+      return index
+    end
+  end
+  return #order + 1
+end
+
 function WSGH.Util.Print(msg)
   DEFAULT_CHAT_FRAME:AddMessage(("|cff33ff99WSGH|r: %s"):format(tostring(msg)))
 end

--- a/WowSimsGearHelper.toc
+++ b/WowSimsGearHelper.toc
@@ -3,7 +3,7 @@
 ## Notes: WSGH helps apply WowSims exports with guided gear changes, highlights, and shopping lists.
 ## IconTexture: Interface\AddOns\WowSimsGearHelper\WowSimsGearHelper_icon.tga
 ## Author: Blazz
-## Version: 1.2.0
+## Version: 1.3.0
 ## OptionalDeps: Masque, ReforgeLite
 ## SavedVariablesPerCharacter: WowSimsGearHelperDB
 

--- a/scripts/preview-release-notes.ps1
+++ b/scripts/preview-release-notes.ps1
@@ -125,7 +125,7 @@ if ([string]::IsNullOrWhiteSpace($curseforgeBody)) {
   $curseforgeBody = "Release $Version"
 }
 
-$fullChangelogUrl = "https://github.com/martinhoite/WowSimsGearHelper/blob/main/CHANGELOG.md"
+$fullChangelogUrl = "https://github.com/martinhoite/WowSimsGearHelper/blob/v$Version/CHANGELOG.md"
 $curseforgeBody = ("[Full changelog]($fullChangelogUrl)`n`n" + $curseforgeBody.Trim())
 
 Write-Host "=== VERSION ==="


### PR DESCRIPTION
## Summary

Adds user-controlled task priority ordering.
Specifically requested as a friend uses the addon in a non-conventional way and completely ignores the gems in the import, so blocking other actions behind that made it unusable to him - while perhaps a bit odd, it sparked the idea for this, you do you :).

## What changed

- Added a drag-and-drop task priority list in Settings.
- Wired the configured order into row action selection, row task badges, and the flat diff task list.
- Defaulted reforging to the last priority and added guidance to upgrade before reforging.
- Updated 1.3.0 release metadata, README beta badge, changelog, and release workflow handling for alpha/beta/stable tag channels.

## Why

This lets users decide which task type the addon should guide them through first when an item has multiple pending actions, while keeping release tagging aligned with the intended feature, release, and main branch flow.