### PR TITLE
Added MoP perfect gem equivalence support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## [1.3.2-alpha.1] - 21 Jun, 2026
+
+### Added
+- MoP perfect uncommon gems now compare as equivalent to matching rare gem cuts when checking socketed gems.
+
 ## [1.3.1] - 18 Jun, 2026
 
 ### Fixed

--- a/Core.lua
+++ b/Core.lua
@@ -3,7 +3,7 @@ local WSGH = _G.WowSimsGearHelper or {}
 _G.WowSimsGearHelper = WSGH
 
 WSGH.ADDON_NAME = ADDON_NAME
-WSGH.VERSION = "1.3.1"
+WSGH.VERSION = "1.3.2-alpha.1"
 
 local function EnsureDB()
   if type(_G.WowSimsGearHelperDB) ~= "table" then

--- a/Data/Gems.lua
+++ b/Data/Gems.lua
@@ -1,0 +1,124 @@
+local WSGH = _G.WowSimsGearHelper or {}
+_G.WowSimsGearHelper = WSGH
+WSGH.Data = WSGH.Data or {}
+
+local mopRareGemToPerfectGemId = {
+  -- River's Heart / Lapis Lazuli
+  [76636] = 76570, -- Rigid
+  [76637] = 76571, -- Stormy
+  [76638] = 76572, -- Sparkling
+  [76639] = 76573, -- Solid
+
+  -- Wild Jade / Alexandrite
+  [76640] = 76574, -- Misty
+  [76641] = 76575, -- Piercing
+  [76642] = 76576, -- Lightning
+  [76643] = 76577, -- Sensei's
+  [76644] = 76578, -- Effulgent
+  [76645] = 76579, -- Zen
+  [76646] = 76580, -- Balanced
+  [76647] = 76581, -- Vivid
+  [76648] = 76582, -- Turbid
+  [76649] = 76583, -- Radiant
+  [76650] = 76584, -- Shattered
+  [76651] = 76585, -- Energized
+  [76652] = 76586, -- Jagged
+  [76653] = 76587, -- Regal
+  [76654] = 76588, -- Forceful
+  [76655] = 76589, -- Confounded
+  [76656] = 76590, -- Puissant
+  [76657] = 76591, -- Steady
+
+  -- Vermilion Onyx / Tiger Opal
+  [76658] = 76592, -- Deadly
+  [76659] = 76593, -- Crafty
+  [76660] = 76594, -- Potent
+  [76661] = 76595, -- Inscribed
+  [76662] = 76596, -- Polished
+  [76663] = 76597, -- Resolute
+  [76664] = 76598, -- Stalwart
+  [76665] = 76599, -- Champion's
+  [76666] = 76600, -- Deft
+  [76667] = 76601, -- Wicked
+  [76668] = 76602, -- Reckless
+  [76669] = 76603, -- Fierce
+  [76670] = 76604, -- Adept
+  [76671] = 76605, -- Keen
+  [76672] = 76606, -- Artful
+  [76673] = 76607, -- Fine
+  [76674] = 76608, -- Skillful
+  [76675] = 76609, -- Lucent
+  [76676] = 76610, -- Tenuous
+  [76677] = 76611, -- Willful
+  [76678] = 76612, -- Splendid
+  [76679] = 76613, -- Resplendent
+
+  -- Imperial Amethyst / Roguestone
+  [76680] = 76614, -- Glinting
+  [76681] = 76615, -- Accurate
+  [76682] = 76616, -- Veiled
+  [76683] = 76617, -- Retaliating
+  [76684] = 76618, -- Etched
+  [76685] = 76619, -- Mysterious
+  [76686] = 76620, -- Purified
+  [76687] = 76621, -- Shifting
+  [76688] = 76622, -- Guardian's
+  [76689] = 76623, -- Timeless
+  [76690] = 76624, -- Defender's
+  [76691] = 76625, -- Sovereign
+
+  -- Primordial Ruby / Pandarian Garnet
+  [76692] = 76626, -- Delicate
+  [76693] = 76627, -- Precise
+  [76694] = 76628, -- Brilliant
+  [76695] = 76629, -- Flashing
+  [76696] = 76630, -- Bold
+
+  -- Sun's Radiance / Sunstone
+  [76697] = 76631, -- Smooth
+  [76698] = 76632, -- Subtle
+  [76699] = 76633, -- Quick
+  [76700] = 76634, -- Fractured
+  [76701] = 76635, -- Mystic
+}
+
+local mopEquivalentRareGemIdByItemId = {}
+for rareGemId, perfectGemId in pairs(mopRareGemToPerfectGemId) do
+  mopEquivalentRareGemIdByItemId[rareGemId] = rareGemId
+  mopEquivalentRareGemIdByItemId[perfectGemId] = rareGemId
+end
+
+local function IsMopGemEquivalenceContext(expansionKey)
+  if expansionKey ~= "MOP" then
+    return false
+  end
+
+  local build = (type(GetBuildInfo) == "function") and select(4, GetBuildInfo()) or 0
+  build = tonumber(build) or 0
+  return build == 0 or build < 60000
+end
+
+local function NormalizeMopGemId(itemId)
+  itemId = tonumber(itemId) or 0
+  if itemId == 0 then return 0 end
+  return mopEquivalentRareGemIdByItemId[itemId] or itemId
+end
+
+local Gems = {}
+
+function Gems.AreEquivalentGemIds(expectedGemId, actualGemId, expansionKey)
+  expectedGemId = tonumber(expectedGemId) or 0
+  actualGemId = tonumber(actualGemId) or 0
+
+  if expectedGemId == actualGemId then
+    return true
+  end
+
+  if not IsMopGemEquivalenceContext(expansionKey) then
+    return false
+  end
+
+  return NormalizeMopGemId(expectedGemId) == NormalizeMopGemId(actualGemId)
+end
+
+WSGH.Data.Gems = Gems

--- a/Diff/Engine.lua
+++ b/Diff/Engine.lua
@@ -107,6 +107,21 @@ local function CollectPresentGemIds(gemsByIndex)
   return ids
 end
 
+local function AreGemIdsEquivalent(expectedGemId, actualGemId, expansionKey)
+  expectedGemId = tonumber(expectedGemId) or 0
+  actualGemId = tonumber(actualGemId) or 0
+  if expectedGemId == actualGemId then
+    return true
+  end
+
+  local gemData = WSGH.Data and WSGH.Data.Gems or nil
+  if gemData and gemData.AreEquivalentGemIds then
+    return gemData.AreEquivalentGemIds(expectedGemId, actualGemId, expansionKey)
+  end
+
+  return false
+end
+
 local function SlotLikelyEnchantable(slotId)
   slotId = tonumber(slotId) or 0
   if slotId == 11 or slotId == 12 then
@@ -179,7 +194,7 @@ local function BuildImportWarningsForSlot(planSlot, equippedSlot)
   return warnings
 end
 
-local function BuildSocketTasksForSlot(slotMeta, planSlot, equippedSlot, bagIndex)
+local function BuildSocketTasksForSlot(slotMeta, planSlot, equippedSlot, bagIndex, expansionKey)
   local tasks = {}
   local deferredTasks = {}
 
@@ -218,7 +233,7 @@ local function BuildSocketTasksForSlot(slotMeta, planSlot, equippedSlot, bagInde
 
         if haveGemId == 0 then
           status = WSGH.Const.STATUS_EMPTY
-        elseif haveGemId ~= wantGemId then
+        elseif not AreGemIdsEquivalent(wantGemId, haveGemId, expansionKey) then
           status = WSGH.Const.STATUS_WRONG
         end
 
@@ -619,6 +634,8 @@ function WSGH.Diff.Engine.Build(plan, equipped, bagIndex)
     tasks = {}, -- flat list of tasks across all rows
     taskCount = 0,
   }
+  local expansionKey = plan.meta and plan.meta.expansionKey or
+    (WSGH.Util and WSGH.Util.GetExpansionKey and WSGH.Util.GetExpansionKey() or nil)
 
   for _, slotMeta in ipairs(WSGH.Const.SLOT_ORDER) do
     local slotId = slotMeta.slotId
@@ -626,7 +643,7 @@ function WSGH.Diff.Engine.Build(plan, equipped, bagIndex)
     local eqSlot = equipped[slotId]
 
     if planSlot and eqSlot then
-      local socketTasks, deferredSocketTasks = BuildSocketTasksForSlot(slotMeta, planSlot, eqSlot, bagIndex)
+      local socketTasks, deferredSocketTasks = BuildSocketTasksForSlot(slotMeta, planSlot, eqSlot, bagIndex, expansionKey)
       local enchantTasks = BuildEnchantTasksForSlot(planSlot, eqSlot, bagIndex)
       local upgradeTasks = BuildUpgradeTasksForSlot(planSlot, eqSlot)
       local reforgeTasks = BuildReforgeTasksForSlot(planSlot, eqSlot)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 WowSims Gear Helper
-<!-- ![Alpha](https://img.shields.io/badge/alpha-0.1.2--alpha.2-blue) -->
-![Alpha](https://img.shields.io/badge/alpha-none-lightgrey)
+![Alpha](https://img.shields.io/badge/alpha-1.3.2--alpha.1-blue)
 ![Beta](https://img.shields.io/badge/beta-none-lightgrey)
 ![Release](https://img.shields.io/badge/release-1.3.1-success)
 ===================

--- a/WowSimsGearHelper.toc
+++ b/WowSimsGearHelper.toc
@@ -3,7 +3,7 @@
 ## Notes: WSGH helps apply WowSims exports with guided gear changes, highlights, and shopping lists.
 ## IconTexture: Interface\AddOns\WowSimsGearHelper\WowSimsGearHelper_icon.tga
 ## Author: Blazz
-## Version: 1.3.1
+## Version: 1.3.2-alpha.1
 ## OptionalDeps: Masque, ReforgeLite
 ## SavedVariablesPerCharacter: WowSimsGearHelperDB
 
@@ -13,6 +13,7 @@ Libs/Json.lua
 
 Constants.lua
 Data/Enchants.lua
+Data/Gems.lua
 Util.lua
 
 Importers/WowSims.lua


### PR DESCRIPTION
## Summary

Adds support for treating MoP perfect uncommon gems as equivalent to their matching rare gem cuts during socket gem checks.

## What changed

* Added equivalency handling for MoP perfect uncommon gems.
* Matching rare gem cuts now satisfy the same socketed gem comparison rules.

## Why

MoP has perfect uncommon gems that are effectively alternate versions of rare cuts, so socket validation should treat them as matching equivalents instead of separate unsupported gem variants.
