### PR TITLE
Feature/color customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to this project are documented in this file.
 
-## [1.3.2-alpha.1] - 21 Jun, 2026
+## [1.4.0-beta.1] - 26 Jun, 2026
+
+### Added
+- Added a Colors settings section with focused previews, per-color help icons, swatches, preset dropdowns, per-color resets, and a confirmed reset-all action.
+- Added customizable color roles for action button text presets, window backgrounds, row titles, shopping text, highlight glow/labels, and settings task-priority states.
+
+### Changed
+- Replaced the separate opaque-background setting with customizable window background colors.
+
+## [1.3.2] - 21 Jun, 2026
 
 ### Added
 - MoP perfect uncommon gems now compare as equivalent to matching rare gem cuts when checking socketed gems.

--- a/Constants.lua
+++ b/Constants.lua
@@ -221,6 +221,79 @@ WSGH.Const.HIGHLIGHT = {
   },
 }
 
+WSGH.Const.COLOR_ROLES = {
+  {
+    heading = "Buttons",
+    roles = {
+      { key = "button.defaultText", label = "Active action text", default = { 1, 0.82, 0, 1 }, description = "Text on enabled row action buttons such as Socket, Equip, Enchant, Upgrade, and Add socket." },
+      { key = "button.reforgeText", label = "Reforge action text", default = { 1, 1, 1, 1 }, description = "Text on the Reforge* row action button." },
+      { key = "button.doneText", label = "Completed action text", default = { 0.72, 0.72, 0.72, 1 }, description = "Text on disabled Done buttons for rows with no remaining tasks." },
+      { key = "button.purchaseText", label = "Purchase action text", default = { 1, 0.82, 0, 1 }, description = "Text on disabled Purchase or Missing buttons when required items are not available." },
+    },
+  },
+  {
+    heading = "Window",
+    roles = {
+      { key = "window.background", label = "Window background", default = { 0.0235, 0.0314, 0.051, 0.88 }, description = "Backdrop color behind the main addon, import, help, and shopping windows." },
+      { key = "window.reminderBackground", label = "Reminder background", default = { 0, 0, 0, 0.75 }, description = "Backdrop color for the small manual reforge reminder popup." },
+      { key = "text.normal", label = "Main window text", default = { 1, 1, 1, 1 }, description = "Primary labels in the main addon window and settings controls." },
+      { key = "text.secondary", label = "Secondary window text", default = { 0.8, 0.8, 0.8, 1 }, description = "Supporting text such as bylines and less prominent labels." },
+      { key = "text.muted", label = "Muted window text", default = { 0.5, 0.5, 0.5, 1 }, description = "Disabled, empty, or low-emphasis text such as row subtitles and no-socket notes." },
+      { key = "accent.gold", label = "Header/accent text", default = { 1, 0.82, 0, 1 }, description = "Section headings and accent labels throughout the addon UI." },
+      { key = "status.warning", label = "Warning text", default = { 1, 0.82, 0.2, 1 }, description = "Warning text in rows, badges, shopping, and tooltips." },
+      { key = "status.error", label = "Error text", default = { 1, 0.2, 0.2, 1 }, description = "Error text for import problems and failed states." },
+    },
+  },
+  {
+    heading = "Rows",
+    roles = {
+      { key = "row.defaultTitle", label = "Default row title", default = { 1, 0.82, 0, 1 }, description = "Equipped-slot row title when the row has normal pending work." },
+      { key = "row.wrongItemTitle", label = "Wrong item title", default = { 1, 0.25, 0.25, 1 }, description = "Equipped-slot row title when the currently equipped item does not match the import." },
+      { key = "row.upgradeTitle", label = "Upgrade row title", default = { 1, 0.62, 0.22, 1 }, description = "Equipped-slot row title when item upgrades are pending." },
+      { key = "row.reforgeTitle", label = "Reforge row title", default = { 0.8, 0.62, 1, 1 }, description = "Equipped-slot row title when only reforge work remains." },
+      { key = "row.subtitle", label = "Row subtitle", default = { 0.5, 0.5, 0.5, 1 }, description = "Small status text under each equipped-slot row title." },
+      { key = "row.background", label = "Row background", default = { 0, 0, 0, 0.18 }, description = "Backdrop fill behind each equipped-slot row." },
+      { key = "row.border", label = "Row border", default = { 0, 0, 0, 0.35 }, description = "Border around each equipped-slot row." },
+    },
+  },
+  {
+    heading = "Shopping",
+    roles = {
+      { key = "shopping.header", label = "Shopping headers", default = { 1, 0.82, 0, 1 }, description = "Category headings in the shopping list window." },
+      { key = "shopping.itemText", label = "Shopping item text", default = { 1, 1, 1, 1 }, description = "Regular item names and counts in the shopping list." },
+      { key = "shopping.completedText", label = "Shopping completed text", default = { 0.72, 0.72, 0.72, 1 }, description = "Shopping-list entries that are already purchased or satisfied." },
+      { key = "shopping.warningText", label = "Shopping warning text", default = { 1, 0.2, 0.2, 1 }, description = "Warnings in the shopping list, such as missing or ambiguous purchase data." },
+      { key = "shopping.reminderText", label = "Reforge reminder text", default = { 1, 0.82, 0, 1 }, description = "Text shown in the manual reforge reminder popup." },
+    },
+  },
+  {
+    heading = "Highlights",
+    roles = {
+      { key = "highlight.glow", label = "Highlight glow", default = { 0.95, 0.95, 0.32, 1 }, description = "Glow color around highlighted bags, items, sockets, and equipment slots." },
+      { key = "highlight.number", label = "Highlight number", default = { 1, 1, 1, 1 }, description = "Number text on ordered bag/item/socket highlights." },
+      { key = "highlight.numberBackground", label = "Highlight number background", default = { 0, 0, 0, 0.85 }, description = "Small backdrop behind ordered highlight numbers." },
+    },
+  },
+  {
+    heading = "Settings",
+    roles = {
+      { key = "settings.dragRowBackground", label = "Dragged row background", default = { 0.2, 0.32, 0.42, 0.85 }, description = "Background for a task-priority row while it is being dragged in settings." },
+      { key = "settings.dragRowBorder", label = "Dragged row border", default = { 0.95, 0.85, 0.25, 1 }, description = "Border for a task-priority row while it is being dragged in settings." },
+      { key = "settings.idleRowBackground", label = "Idle row background", default = { 0.03, 0.03, 0.03, 0.45 }, description = "Background for task-priority rows while they are not being dragged." },
+      { key = "settings.idleRowBorder", label = "Idle row border", default = { 0.35, 0.35, 0.35, 1 }, description = "Border for task-priority rows while they are not being dragged." },
+    },
+  },
+}
+
+WSGH.Const.COLOR_DEFAULTS = {}
+for _, colorGroup in ipairs(WSGH.Const.COLOR_ROLES) do
+  for _, colorRole in ipairs(colorGroup.roles or {}) do
+    if colorRole.key then
+      WSGH.Const.COLOR_DEFAULTS[colorRole.key] = colorRole.default
+    end
+  end
+end
+
 WSGH.Const.ICON_EMPTY_SOCKET = "Interface\\ItemSocketingFrame\\UI-EmptySocket"
 WSGH.Const.TINKERS_KIT_ITEM_ID = 90146
 WSGH.Const.JUSTICE_POINTS_CURRENCY_ID = 395
@@ -278,6 +351,13 @@ WSGH.Const.UI = {
     categories = { "Gems", "Enchants", "Other" },
   },
   settings = {
+    scroll = {
+      childWidth = 640,
+      minChildHeight = 760,
+      bottomPadding = 36,
+      rightInset = 28,
+      mouseWheelStep = 36,
+    },
     taskPriority = {
       xOffset = 320,
       yOffset = -8,
@@ -295,6 +375,38 @@ WSGH.Const.UI = {
         tileSize = 16,
         edgeSize = 10,
         inset = 2,
+      },
+    },
+    colors = {
+      width = 560,
+      height = 820,
+      contentHeight = 800,
+      noteWidth = 520,
+      preview = { width = 540, height = 44, yOffset = -34 },
+      openWindowButton = { width = 92, height = 20, xOffset = -118, yOffset = 2 },
+      resetAllButton = { width = 104, height = 20, xOffset = -8, yOffset = 2 },
+      row = {
+        topOffset = -98,
+        headingGap = 20,
+        rowHeight = 24,
+        groupGap = 4,
+        labelX = 8,
+        labelYOffset = -2,
+        labelWidth = 170,
+        helpX = 166,
+        helpYOffset = -3,
+        helpWidth = 14,
+        helpHeight = 14,
+        swatchX = 184,
+        swatchWidth = 22,
+        swatchHeight = 18,
+        dropdownOffsetX = -10,
+        dropdownOffsetY = 2,
+        dropdownWidth = 112,
+        resetOffsetX = -6,
+        resetOffsetY = 2,
+        resetWidth = 44,
+        resetHeight = 20,
       },
     },
   },

--- a/Core.lua
+++ b/Core.lua
@@ -3,7 +3,7 @@ local WSGH = _G.WowSimsGearHelper or {}
 _G.WowSimsGearHelper = WSGH
 
 WSGH.ADDON_NAME = ADDON_NAME
-WSGH.VERSION = "1.3.2-alpha.1"
+WSGH.VERSION = "1.4.0-beta.1"
 
 local function EnsureDB()
   if type(_G.WowSimsGearHelperDB) ~= "table" then

--- a/Core.lua
+++ b/Core.lua
@@ -33,8 +33,8 @@ local function EnsureDB()
       syncImportsToReforgeLite = true,
       minimizeWindowAtReforgeNpc = true,
       restoreWindowAfterReforgeNpc = false,
-      useOpaqueBackgroundForAllWindows = false,
       tinkers = {},
+      colors = {},
       upgradeCurrency = "JUSTICE",
       useValorForUpgrades = false,
       taskPriorityOrder = WSGH.Util.GetDefaultTaskPriorityOrder and WSGH.Util.GetDefaultTaskPriorityOrder() or {},
@@ -48,8 +48,8 @@ local function EnsureDB()
   if prefs.syncImportsToReforgeLite == nil then prefs.syncImportsToReforgeLite = true end
   if prefs.minimizeWindowAtReforgeNpc == nil then prefs.minimizeWindowAtReforgeNpc = true end
   if prefs.restoreWindowAfterReforgeNpc == nil then prefs.restoreWindowAfterReforgeNpc = false end
-  if prefs.useOpaqueBackgroundForAllWindows == nil then prefs.useOpaqueBackgroundForAllWindows = false end
   if prefs.tinkers == nil then prefs.tinkers = {} end
+  if type(prefs.colors) ~= "table" then prefs.colors = {} end
   if prefs.minimap == nil then prefs.minimap = { hide = false } end
   if prefs.minimap.hide == nil then prefs.minimap.hide = false end
   if prefs.upgradeCurrency == nil then prefs.upgradeCurrency = "JUSTICE" end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 WowSims Gear Helper
-![Alpha](https://img.shields.io/badge/alpha-1.3.2--alpha.1-blue)
-![Beta](https://img.shields.io/badge/beta-none-lightgrey)
+<!-- ![Alpha](https://img.shields.io/badge/alpha-1.3.3--alpha.1-blue) -->
+<!-- ![Beta](https://img.shields.io/badge/beta-none-lightgrey) -->
+![Alpha](https://img.shields.io/badge/alpha-none-lightgrey)
+![Beta](https://img.shields.io/badge/beta-1.4.0-orange)
 ![Release](https://img.shields.io/badge/release-1.3.1-success)
 ===================
 
@@ -17,6 +19,7 @@ Features
 - Optional ReforgeLite Classic import sync for WowSims reforges.
 - Bag/character slot highlighting to guide actions.
 - Live shopping list updates as items are bought / obtained from mailbox.
+- Customizable UI colors for buttons, windows, rows, shopping text, highlights, and settings states.
 - Built-in quick help plus a more detailed import walkthrough.
 
 Supported Bag Addons

--- a/UI.lua
+++ b/UI.lua
@@ -53,6 +53,19 @@ local function IsFrameVisible(frame)
   return frame:IsShown()
 end
 
+local function GetColor(roleKey)
+  if WSGH.Util and WSGH.Util.GetColor then
+    return WSGH.Util.GetColor(roleKey)
+  end
+  return { 1, 1, 1, 1 }
+end
+
+local function SetFontColor(fontString, roleKey)
+  if not (fontString and fontString.SetTextColor) then return end
+  local color = GetColor(roleKey)
+  fontString:SetTextColor(color[1], color[2], color[3], color[4])
+end
+
 local function CloseUIForCombat()
   if not (
     IsFrameVisible(WSGH.UI.frame)
@@ -149,18 +162,18 @@ local function RefreshReforgeReminder()
 end
 
 function WSGH.UI.RefreshWindowBackgrounds()
-  if not (WSGH.Util and WSGH.Util.ApplyOpaqueWindowBackground) then return end
+  if not (WSGH.Util and WSGH.Util.ApplyWindowBackground) then return end
 
-  WSGH.Util.ApplyOpaqueWindowBackground(WSGH.UI.frame, "main")
-  WSGH.Util.ApplyOpaqueWindowBackground(WSGH.UI.shoppingFrame, "shopping")
-  WSGH.Util.ApplyOpaqueWindowBackground(WSGH.UI.shoppingReminder, "shoppingReminder", 3)
+  WSGH.Util.ApplyWindowBackground(WSGH.UI.frame, "main")
+  WSGH.Util.ApplyWindowBackground(WSGH.UI.shoppingFrame, "shopping")
+  WSGH.Util.ApplyWindowBackground(WSGH.UI.shoppingReminder, "shoppingReminder", 3)
 
   if WSGH.UI.Help and WSGH.UI.Help.dialog then
-    WSGH.Util.ApplyOpaqueWindowBackground(WSGH.UI.Help.dialog, "help")
+    WSGH.Util.ApplyWindowBackground(WSGH.UI.Help.dialog, "help")
   end
 
   if WSGH.UI.importDialog then
-    WSGH.Util.ApplyOpaqueWindowBackground(WSGH.UI.importDialog, "import")
+    WSGH.Util.ApplyWindowBackground(WSGH.UI.importDialog, "import")
   end
 end
 
@@ -1832,8 +1845,8 @@ function WSGH.UI.Init()
     edgeSize = 32,
     insets = { left = 11, right = 12, top = 12, bottom = 11 },
   })
-  if WSGH.Util and WSGH.Util.ApplyOpaqueWindowBackground then
-    WSGH.Util.ApplyOpaqueWindowBackground(mainFrame, "main")
+  if WSGH.Util and WSGH.Util.ApplyWindowBackground then
+    WSGH.Util.ApplyWindowBackground(mainFrame, "main")
   end
 
   RestorePosition(mainFrame)
@@ -1843,11 +1856,13 @@ function WSGH.UI.Init()
   local title = mainFrame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
   title:SetPoint("TOPLEFT", 18, -16)
   title:SetText("WowSims Gear Helper")
+  SetFontColor(title, "accent.gold")
 
   local addonVersion = WSGH.Util and WSGH.Util.GetAddonVersion and WSGH.Util.GetAddonVersion() or (WSGH.VERSION or "unknown")
   local versionLabel = mainFrame:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
   versionLabel:SetPoint("LEFT", title, "RIGHT", 8, -1)
   versionLabel:SetText(("v%s"):format(tostring(addonVersion)))
+  SetFontColor(versionLabel, "text.secondary")
 
   local helpBtn = CreateFrame("Button", nil, mainFrame, "UIPanelButtonTemplate")
   helpBtn:SetSize(WSGH.Const.UI.help.iconButton.width, WSGH.Const.UI.help.iconButton.height)
@@ -1866,7 +1881,7 @@ function WSGH.UI.Init()
   local attribution = mainFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
   attribution:SetPoint("LEFT", versionLabel, "RIGHT", 8, 0)
   attribution:SetText(("by |c%sBlazzmonk|r - Garalon EU"):format(monkColorCode))
-  attribution:SetTextColor(1, 1, 1, 1)
+  SetFontColor(attribution, "text.normal")
 
   local headerButtons = WSGH.Const.UI.headerButtons
   local close = CreateFrame("Button", nil, mainFrame, "UIPanelCloseButton")
@@ -1894,6 +1909,7 @@ function WSGH.UI.Init()
   local summary = mainFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
   summary:SetPoint("LEFT", settingsBtn, "RIGHT", 10, 0)
   summary:SetText("No plan imported")
+  SetFontColor(summary, "text.normal")
 
   local expandAfterReforgeBtn = CreateFrame("Button", nil, mainFrame)
   expandAfterReforgeBtn:SetSize(
@@ -1932,6 +1948,7 @@ function WSGH.UI.Init()
   local listLabel = mainFrame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
   listLabel:SetPoint("TOPLEFT", 18, -78)
   listLabel:SetText("Equipped slots")
+  SetFontColor(listLabel, "accent.gold")
 
   local listWarningChip = CreateFrame("Button", nil, mainFrame)
   listWarningChip:SetPoint("LEFT", listLabel, "RIGHT", 10, 0)
@@ -1948,7 +1965,7 @@ function WSGH.UI.Init()
   local listWarningText = listWarningChip:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
   listWarningText:SetPoint("LEFT", listWarningIcon, "RIGHT", 4, 0)
   listWarningText:SetJustifyH("LEFT")
-  listWarningText:SetTextColor(1, 0.2, 0.2, 1)
+  SetFontColor(listWarningText, "status.error")
   listWarningText:SetText("")
 
   local scroll = CreateFrame("ScrollFrame", "WowSimsGearHelperScroll", mainFrame, "FauxScrollFrameTemplate")
@@ -2001,25 +2018,27 @@ function WSGH.UI.Init()
     edgeSize = 32,
     insets = { left = 11, right = 12, top = 12, bottom = 11 },
   })
-  if WSGH.Util and WSGH.Util.ApplyOpaqueWindowBackground then
-    WSGH.Util.ApplyOpaqueWindowBackground(sidebar, "shopping")
+  if WSGH.Util and WSGH.Util.ApplyWindowBackground then
+    WSGH.Util.ApplyWindowBackground(sidebar, "shopping")
   end
 
   local sidebarTitle = sidebar:CreateFontString(nil, "OVERLAY", "GameFontNormal")
   sidebarTitle:SetPoint("TOPLEFT", 14, -14)
   sidebarTitle:SetText("Shopping List")
+  SetFontColor(sidebarTitle, "accent.gold")
 
   local shoppingByline = sidebar:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
   shoppingByline:SetPoint("TOPLEFT", sidebarTitle, "BOTTOMLEFT", 0, -4)
   shoppingByline:SetJustifyH("LEFT")
   shoppingByline:SetWordWrap(true)
-  shoppingByline:SetTextColor(1, 0.2, 0.2, 1)
+  SetFontColor(shoppingByline, "shopping.warningText")
   shoppingByline:SetText("")
   shoppingByline:Hide()
 
   local shoppingEmpty = sidebar:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
   shoppingEmpty:SetPoint("TOPLEFT", shoppingByline, "BOTTOMLEFT", 0, -8)
   shoppingEmpty:SetText("No missing items")
+  SetFontColor(shoppingEmpty, "text.muted")
 
   local shoppingReminder = CreateFrame("Frame", nil, mainFrame, "BackdropTemplate")
   shoppingReminder:SetPoint("TOPLEFT", sidebar, "BOTTOMLEFT", 10, -4)
@@ -2037,15 +2056,15 @@ function WSGH.UI.Init()
   })
   shoppingReminder:SetBackdropColor(0, 0, 0, 0.75)
   shoppingReminder:SetBackdropBorderColor(0.45, 0.45, 0.45, 1)
-  if WSGH.Util and WSGH.Util.ApplyOpaqueWindowBackground then
-    WSGH.Util.ApplyOpaqueWindowBackground(shoppingReminder, "shoppingReminder", 3)
+  if WSGH.Util and WSGH.Util.ApplyWindowBackground then
+    WSGH.Util.ApplyWindowBackground(shoppingReminder, "shoppingReminder", 3)
   end
   shoppingReminder:Hide()
 
   local shoppingReminderLabel = shoppingReminder:CreateFontString(nil, "OVERLAY", "GameFontNormal")
   shoppingReminderLabel:SetPoint("LEFT", WSGH.Const.UI.shopping.reminder.padding, 0)
   shoppingReminderLabel:SetText("Did you reforge?")
-  shoppingReminderLabel:SetTextColor(1, 0.82, 0, 1)
+  SetFontColor(shoppingReminderLabel, "shopping.reminderText")
 
   local shoppingReminderDone = CreateFrame("Button", nil, shoppingReminder, "UIPanelButtonTemplate")
   shoppingReminderDone:SetSize(
@@ -2186,6 +2205,7 @@ function WSGH.UI.Init()
 
   WSGH.UI.frame = mainFrame
   WSGH.UI.title = title
+  WSGH.UI.versionLabel = versionLabel
   WSGH.UI.attribution = attribution
   WSGH.UI.summary = summary
   WSGH.UI.expandAfterReforgeBtn = expandAfterReforgeBtn
@@ -2199,6 +2219,7 @@ function WSGH.UI.Init()
   WSGH.UI.rowRightPad = rowRightPad
   WSGH.UI.listWarningChip = listWarningChip
   WSGH.UI.listWarningText = listWarningText
+  WSGH.UI.listLabel = listLabel
   WSGH.UI.mainBodyFrames = { listLabel, listWarningChip, scroll }
   WSGH.UI.shoppingFrame = sidebar
   WSGH.UI.shoppingTitle = sidebarTitle
@@ -2222,6 +2243,32 @@ function WSGH.UI.Init()
 
   LayoutRows()
   SetAuxiliaryFramesShown(false)
+end
+
+function WSGH.UI.RefreshColors()
+  SetFontColor(WSGH.UI.title, "accent.gold")
+  SetFontColor(WSGH.UI.versionLabel, "text.secondary")
+  SetFontColor(WSGH.UI.attribution, "text.normal")
+  SetFontColor(WSGH.UI.summary, "text.normal")
+  SetFontColor(WSGH.UI.listLabel, "accent.gold")
+  SetFontColor(WSGH.UI.listWarningText, "status.error")
+  SetFontColor(WSGH.UI.shoppingTitle, "accent.gold")
+  SetFontColor(WSGH.UI.shoppingByline, "shopping.warningText")
+  SetFontColor(WSGH.UI.shoppingEmpty, "text.muted")
+  SetFontColor(WSGH.UI.shoppingReminderLabel, "shopping.reminderText")
+  if WSGH.UI.RefreshWindowBackgrounds then
+    WSGH.UI.RefreshWindowBackgrounds()
+  end
+
+  if WSGH.UI.Render then
+    WSGH.UI.Render()
+  end
+  if WSGH.UI.Shopping and WSGH.UI.Shopping.UpdateShoppingList then
+    WSGH.UI.Shopping.UpdateShoppingList()
+  end
+  if WSGH.UI.Highlight and WSGH.UI.Highlight.Refresh then
+    WSGH.UI.Highlight.Refresh()
+  end
 end
 
 function WSGH.UI.Render()
@@ -2284,6 +2331,8 @@ function WSGH.UI.Render()
       WSGH.UI.listWarningChip:Show()
       WSGH.UI.listWarningChip:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        local warningColor = GetColor("status.warning")
+        local normalColor = GetColor("text.normal")
         local categories = {}
         if hasGemWarning then categories[#categories + 1] = "gems" end
         if hasEnchantWarning then categories[#categories + 1] = "enchant" end
@@ -2292,12 +2341,12 @@ function WSGH.UI.Render()
         if #categories > 0 then
           titleText = titleText .. ": " .. table.concat(categories, ", ")
         end
-        GameTooltip:SetText(titleText, 1, 0.82, 0.2)
-        GameTooltip:AddLine("Affected slots: " .. table.concat(warningSlots, ", "), 1, 1, 1, true)
-        GameTooltip:AddLine(" ", 1, 1, 1, true)
-        GameTooltip:AddLine("Import data may be incomplete.", 1, 0.82, 0.2, true)
-        GameTooltip:AddLine("Please verify your import and update if it's incorrect.", 1, 0.82, 0.2, true)
-        GameTooltip:AddLine("Hover row ? icons for more information.", 1, 0.82, 0.2, true)
+        GameTooltip:SetText(titleText, warningColor[1], warningColor[2], warningColor[3])
+        GameTooltip:AddLine("Affected slots: " .. table.concat(warningSlots, ", "), normalColor[1], normalColor[2], normalColor[3], true)
+        GameTooltip:AddLine(" ", normalColor[1], normalColor[2], normalColor[3], true)
+        GameTooltip:AddLine("Import data may be incomplete.", warningColor[1], warningColor[2], warningColor[3], true)
+        GameTooltip:AddLine("Please verify your import and update if it's incorrect.", warningColor[1], warningColor[2], warningColor[3], true)
+        GameTooltip:AddLine("Hover row ? icons for more information.", warningColor[1], warningColor[2], warningColor[3], true)
         GameTooltip:Show()
       end)
       WSGH.UI.listWarningChip:SetScript("OnLeave", GameTooltip_Hide)

--- a/UI/Help.lua
+++ b/UI/Help.lua
@@ -120,8 +120,8 @@ function Help.EnsureDialog()
     insets = { left = 11, right = 12, top = 12, bottom = 11 },
   })
   table.insert(UISpecialFrames, "WowSimsGearHelperHelpDialog")
-  if WSGH.Util and WSGH.Util.ApplyOpaqueWindowBackground then
-    WSGH.Util.ApplyOpaqueWindowBackground(dialog, "help")
+  if WSGH.Util and WSGH.Util.ApplyWindowBackground then
+    WSGH.Util.ApplyWindowBackground(dialog, "help")
   end
 
   local title = dialog:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")

--- a/UI/Highlight.lua
+++ b/UI/Highlight.lua
@@ -3,6 +3,13 @@ WSGH.UI = WSGH.UI or {}
 WSGH.UI.Highlight = WSGH.UI.Highlight or {}
 local LibCustomGlow = _G.LibStub and _G.LibStub("LibCustomGlow-1.0", true) or nil
 
+local function GetColor(roleKey)
+  if WSGH.Util and WSGH.Util.GetColor then
+    return WSGH.Util.GetColor(roleKey)
+  end
+  return { 1, 1, 1, 1 }
+end
+
 local HighlightState = {
   target = nil,
   targets = nil,
@@ -291,7 +298,8 @@ local function CreateIndicator(parent)
 
   local label = indicator:CreateFontString(nil, "OVERLAY", "GameFontHighlightLarge")
   label:SetPoint("TOPLEFT", indicator, "TOPLEFT", -8, 8)
-  label:SetTextColor(1, 1, 1, 1)
+  local numberColor = GetColor("highlight.number")
+  label:SetTextColor(numberColor[1], numberColor[2], numberColor[3], numberColor[4])
   local font, _, flags = label:GetFont()
   if font then
     label:SetFont(font, 18, flags or "OUTLINE")
@@ -299,7 +307,13 @@ local function CreateIndicator(parent)
   indicator.label = label
 
   local labelBg = indicator:CreateTexture(nil, "ARTWORK")
-  labelBg:SetColorTexture(0, 0, 0, 0.85)
+  local numberBackgroundColor = GetColor("highlight.numberBackground")
+  labelBg:SetColorTexture(
+    numberBackgroundColor[1],
+    numberBackgroundColor[2],
+    numberBackgroundColor[3],
+    numberBackgroundColor[4]
+  )
   labelBg:SetPoint("TOPLEFT", label, "TOPLEFT", -2, 2)
   labelBg:SetPoint("BOTTOMRIGHT", label, "BOTTOMRIGHT", 2, -2)
   indicator.labelBg = labelBg
@@ -352,11 +366,12 @@ local function ResyncOverlayGlowProxy(parent, proxy)
 end
 
 local function BuildGlowColor()
-  local color = WSGH.Const and WSGH.Const.HIGHLIGHT and WSGH.Const.HIGHLIGHT.color or { 1, 0.8, 0.1 }
+  local color = GetColor("highlight.glow")
   local r = tonumber(color[1]) or 1
   local g = tonumber(color[2]) or 0.8
   local b = tonumber(color[3]) or 0.1
-  return { r, g, b, 1 }
+  local a = tonumber(color[4]) or 1
+  return { r, g, b, a }
 end
 
 local function StartAutoCastStyle(proxy, style)
@@ -398,7 +413,7 @@ local function ApplyHighlightStyle(parent, context, attemptsLeft)
   if style == "glow" then
     if LibCustomGlow and LibCustomGlow.ButtonGlow_Start then
       if proxy then
-        LibCustomGlow.ButtonGlow_Start(proxy)
+        LibCustomGlow.ButtonGlow_Start(proxy, BuildGlowColor())
         return
       end
     end
@@ -452,6 +467,17 @@ end
 
 local function SetIndicatorLabel(indicator, text)
   if not (indicator and indicator.label) then return end
+  local numberColor = GetColor("highlight.number")
+  indicator.label:SetTextColor(numberColor[1], numberColor[2], numberColor[3], numberColor[4])
+  if indicator.labelBg then
+    local numberBackgroundColor = GetColor("highlight.numberBackground")
+    indicator.labelBg:SetColorTexture(
+      numberBackgroundColor[1],
+      numberBackgroundColor[2],
+      numberBackgroundColor[3],
+      numberBackgroundColor[4]
+    )
+  end
   indicator.label:SetText(text or "")
   if text and text ~= "" then
     indicator.label:Show()
@@ -1536,6 +1562,18 @@ function WSGH.UI.Highlight.SetSocketHintTarget(itemId, slotId, extraItemId)
   HighlightState.socketHint.slotId = (slot ~= 0) and slot or nil
   ClearSocketHintIndicators()
   WSGH.UI.Highlight.Refresh()
+end
+
+function WSGH.UI.Highlight.ApplyPreview(parent, labelText)
+  if not parent then return end
+  ClearIndicator(parent)
+
+  local indicator = CreateIndicator(parent)
+  if not indicator then return end
+  ConfigureIndicatorForBag(indicator)
+  SetIndicatorLabel(indicator, labelText or "1")
+  indicator:Show()
+  ApplyHighlightStyle(parent, "bag", 0)
 end
 
 function WSGH.UI.Highlight.ClearAll()

--- a/UI/ImportDialog.lua
+++ b/UI/ImportDialog.lua
@@ -53,8 +53,8 @@ function WSGH.UI.EnsureImportDialog()
     edgeSize = 32,
     insets = { left = 11, right = 12, top = 12, bottom = 11 },
   })
-  if WSGH.Util and WSGH.Util.ApplyOpaqueWindowBackground then
-    WSGH.Util.ApplyOpaqueWindowBackground(dialog, "import")
+  if WSGH.Util and WSGH.Util.ApplyWindowBackground then
+    WSGH.Util.ApplyWindowBackground(dialog, "import")
   end
 
   table.insert(UISpecialFrames, "WowSimsGearHelperImportDialog")

--- a/UI/Rows.lua
+++ b/UI/Rows.lua
@@ -2,6 +2,31 @@ local WSGH = _G.WowSimsGearHelper
 WSGH.UI = WSGH.UI or {}
 WSGH.UI.Rows = WSGH.UI.Rows or {}
 
+local function GetColor(roleKey)
+  if WSGH.Util and WSGH.Util.GetColor then
+    return WSGH.Util.GetColor(roleKey)
+  end
+  return { 1, 1, 1, 1 }
+end
+
+local function SetFontColor(fontString, roleKey)
+  if not (fontString and fontString.SetTextColor) then return end
+  local color = GetColor(roleKey)
+  fontString:SetTextColor(color[1], color[2], color[3], color[4])
+end
+
+local function SetBackdropColor(frame, roleKey, borderRoleKey)
+  if not frame then return end
+  if frame.SetBackdropColor then
+    local color = GetColor(roleKey)
+    frame:SetBackdropColor(color[1], color[2], color[3], color[4])
+  end
+  if borderRoleKey and frame.SetBackdropBorderColor then
+    local borderColor = GetColor(borderRoleKey)
+    frame:SetBackdropBorderColor(borderColor[1], borderColor[2], borderColor[3], borderColor[4])
+  end
+end
+
 local function GetItemNameAndIcon(itemId)
   if not itemId or itemId == 0 then return nil, nil end
   local name, _, _, _, _, _, _, _, _, icon = GetItemInfo(itemId)
@@ -26,18 +51,12 @@ local function StatusIcon(status)
   return WSGH.Const.ICON_NOTREADY
 end
 
-local function SetActionButtonReforgeStyle(button, enabled)
+local function SetActionButtonStyle(button, textRoleKey)
   if not button then return end
-
-  if enabled then
-    if button.GetFontString and button:GetFontString() then
-      button:GetFontString():SetTextColor(1, 1, 1, 1)
-    end
-    return
-  end
-
-  if button.GetFontString and button:GetFontString() then
-    button:GetFontString():SetTextColor(1, 0.82, 0, 1)
+  if WSGH.Util and WSGH.Util.ApplyButtonTextColor then
+    WSGH.Util.ApplyButtonTextColor(button, textRoleKey or "button.defaultText")
+  elseif button.GetFontString and button:GetFontString() then
+    SetFontColor(button:GetFontString(), textRoleKey or "button.defaultText")
   end
 end
 
@@ -199,8 +218,6 @@ local function BuildCurrentGemLines(gemIds)
   return lines
 end
 
-local badgeCategoryColor = { 1, 0.82, 0 }
-local badgeTextColor = { 1, 1, 1 }
 local badgeTooltipTitleFont = nil
 local previousBadgeTooltipTitleFontObject = nil
 
@@ -255,14 +272,16 @@ end
 local function AddBadgeCategory(state, title, lines)
   if type(lines) ~= "table" or #lines == 0 then return false end
   state = state or {}
+  local categoryColor = GetColor("accent.gold")
+  local textColor = GetColor("text.normal")
   GameTooltip:AddLine(" ")
-  GameTooltip:AddLine(title, badgeCategoryColor[1], badgeCategoryColor[2], badgeCategoryColor[3])
+  GameTooltip:AddLine(title, categoryColor[1], categoryColor[2], categoryColor[3])
   for _, line in ipairs(lines) do
     local text = type(line) == "table" and line.text or tostring(line)
-    local r = type(line) == "table" and line.r or badgeTextColor[1]
-    local g = type(line) == "table" and line.g or badgeTextColor[2]
-    local b = type(line) == "table" and line.b or badgeTextColor[3]
-    GameTooltip:AddLine("  - " .. tostring(text), r or badgeTextColor[1], g or badgeTextColor[2], b or badgeTextColor[3], true)
+    local r = type(line) == "table" and line.r or textColor[1]
+    local g = type(line) == "table" and line.g or textColor[2]
+    local b = type(line) == "table" and line.b or textColor[3]
+    GameTooltip:AddLine("  - " .. tostring(text), r or textColor[1], g or textColor[2], b or textColor[3], true)
   end
   state.hasCategory = true
   return true
@@ -541,8 +560,7 @@ function WSGH.UI.Rows.Create(parent)
     edgeSize = 10,
     insets = { left = 2, right = 2, top = 2, bottom = 2 },
   })
-  rowFrame:SetBackdropColor(0, 0, 0, 0.18)
-  rowFrame:SetBackdropBorderColor(0, 0, 0, 0.35)
+  SetBackdropColor(rowFrame, "row.background", "row.border")
 
   rowFrame.action = CreateFrame("Button", nil, rowFrame, "UIPanelButtonTemplate")
   rowFrame.action:SetSize(80, 22)
@@ -636,6 +654,7 @@ function WSGH.UI.Rows.Create(parent)
   rowFrame.noSockets:SetPoint("RIGHT", rowFrame.socketsContainer, "RIGHT", 0, 0)
   rowFrame.noSockets:SetJustifyH("CENTER")
   rowFrame.noSockets:SetText("No sockets")
+  SetFontColor(rowFrame.noSockets, "text.muted")
 
   return rowFrame
 end
@@ -644,6 +663,7 @@ end
 
 function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
   rowFrame.rowData = rowData
+  SetBackdropColor(rowFrame, "row.background", "row.border")
 
   local expectedItemId = tonumber(rowData.expectedItemId) or 0
   local equippedItemId = tonumber(rowData.equippedItemId) or 0
@@ -739,13 +759,13 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
   local nextPriorityEnchantTask = priority and priority.nextEnchantTask or nil
 
   if rowData.rowStatus == "WRONG_ITEM" then
-    rowFrame.title:SetTextColor(1, 0.25, 0.25)
+    SetFontColor(rowFrame.title, "row.wrongItemTitle")
   elseif hasUpgradeWork then
-    rowFrame.title:SetTextColor(1, 0.62, 0.22)
+    SetFontColor(rowFrame.title, "row.upgradeTitle")
   elseif hasReforgeWork then
-    rowFrame.title:SetTextColor(0.8, 0.62, 1)
+    SetFontColor(rowFrame.title, "row.reforgeTitle")
   else
-    rowFrame.title:SetTextColor(1, 0.82, 0)
+    SetFontColor(rowFrame.title, "row.defaultTitle")
   end
 
   local importWarnings = rowData.importWarnings or {}
@@ -775,8 +795,9 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
   else
     statusText = ("%d tasks left"):format(remainingTaskCount)
   end
-  rowFrame.subtitle:SetTextColor(0.5, 0.5, 0.5)
+  SetFontColor(rowFrame.subtitle, "row.subtitle")
   rowFrame.subtitle:SetText(statusText)
+  SetFontColor(rowFrame.noSockets, "text.muted")
 
   local enchantDisplays = rowData.enchantDisplays or {}
   local showAmbiguousEnchantPlaceholder = hasEnchantOmissionWarning and #enchantDisplays == 0 and rowData.rowStatus ~= "WRONG_ITEM"
@@ -993,21 +1014,27 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
     rowFrame.noSockets:SetShown(socketCount == 0)
   end
 
-  rowFrame.action:SetScript("OnClick", function()
-    if onAction then onAction(rowData) end
-  end)
-  SetActionButtonReforgeStyle(rowFrame.action, false)
+  rowFrame.action:SetEnabled(true)
+  rowFrame.action:SetScript("OnEnter", nil)
+  rowFrame.action:SetScript("OnLeave", nil)
+  rowFrame.action:SetScript("OnClick", nil)
+  local actionIsClickable = true
+  local actionTextRole = "button.defaultText"
 
   if rowData.rowStatus == "OK" then
     rowFrame.action:SetEnabled(false)
+    actionIsClickable = false
     rowFrame.action:SetText("Done")
+    actionTextRole = "button.doneText"
   elseif rowData.rowStatus == "WRONG_ITEM" then
     if rowData.hasExpectedInBags then
       rowFrame.action:SetEnabled(true)
       rowFrame.action:SetText("Equip")
     else
       rowFrame.action:SetEnabled(false)
+      actionIsClickable = false
       rowFrame.action:SetText("Missing")
+      actionTextRole = "button.purchaseText"
     end
   else
     local hasBlockingTask = false -- e.g., gem/vellum missing from bags; user must acquire it first.
@@ -1039,7 +1066,9 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
 
     if isNextActionMissing or (not nextPriorityAction and hasBlockingTask) then
       rowFrame.action:SetEnabled(false)
+      actionIsClickable = false
       rowFrame.action:SetText("Purchase")
+      actionTextRole = "button.purchaseText"
       rowFrame.action:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         GameTooltip:SetText("Purchase required items first.")
@@ -1100,7 +1129,7 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
     elseif nextActionType == "REFORGE_ITEM" or (not nextActionType and hasPriorityReforge and not hasPriorityAnyEnchant and not hasPriorityUpgrade) then
       rowFrame.action:SetEnabled(true)
       rowFrame.action:SetText("Reforge*")
-      SetActionButtonReforgeStyle(rowFrame.action, true)
+      actionTextRole = "button.reforgeText"
       local firstReforgeTask = nextActionTask or (rowData.reforgeTasks and rowData.reforgeTasks[1] or nil)
       local reforgeText = firstReforgeTask and firstReforgeTask.wantReforgeText or nil
       if firstReforgeTask and (tonumber(firstReforgeTask.wantReforgeId) or 0) == 0 then
@@ -1130,4 +1159,12 @@ function WSGH.UI.Rows.SetRow(rowFrame, rowData, onAction)
       rowFrame.action:SetScript("OnLeave", nil)
     end
   end
+  if actionIsClickable then
+    rowFrame.action:SetScript("OnClick", function()
+      if onAction then onAction(rowData) end
+    end)
+  else
+    rowFrame.action:SetScript("OnClick", nil)
+  end
+  SetActionButtonStyle(rowFrame.action, actionTextRole)
 end

--- a/UI/Settings.lua
+++ b/UI/Settings.lua
@@ -6,9 +6,93 @@ WSGH.UI.Settings = WSGH.UI.Settings or {}
 local optionsPanel
 local optionsCategory
 local optionsCategoryID
+local colorRows = {}
+local colorPreview = {}
+local colorResetAllButton = nil
+local colorOpenWindowButton = nil
+local colorSectionFrame = nil
+local colorSectionContent = nil
+local colorSectionHeight = 760
+local settingsScrollContent = nil
+local settingsScrollFrame = nil
+local settingsScrollContentHeight = 760
+
+local COLOR_PRESETS = {
+  { text = "Default", value = "DEFAULT" },
+  { text = "Custom...", value = "CUSTOM_PICKER", customPicker = true },
+  { text = "White", value = "WHITE", color = { 1, 1, 1, 1 } },
+  { text = "Gold", value = "GOLD", color = { 1, 0.82, 0, 1 } },
+  { text = "Red", value = "RED", color = { 1, 0.2, 0.2, 1 } },
+  { text = "Orange", value = "ORANGE", color = { 1, 0.62, 0.22, 1 } },
+  { text = "Purple", value = "PURPLE", color = { 0.8, 0.62, 1, 1 } },
+  { text = "Blue", value = "BLUE", color = { 0.35, 0.65, 1, 1 } },
+  { text = "Green", value = "GREEN", color = { 0.33, 1, 0.6, 1 } },
+  { text = "Gray", value = "GRAY", color = { 0.72, 0.72, 0.72, 1 } },
+  { text = "Black", value = "BLACK", color = { 0, 0, 0, 1 } },
+}
 
 local function GetPreferences()
   return WSGH.Util and WSGH.Util.GetPreferences and WSGH.Util.GetPreferences() or nil
+end
+
+local function GetColor(roleKey)
+  if WSGH.Util and WSGH.Util.GetColor then
+    return WSGH.Util.GetColor(roleKey)
+  end
+  return { 1, 1, 1, 1 }
+end
+
+local function SetFontColor(fontString, roleKey)
+  if not (fontString and fontString.SetTextColor) then return end
+  local color = GetColor(roleKey)
+  fontString:SetTextColor(color[1], color[2], color[3], color[4])
+end
+
+local function SetFrameBackdropColor(frame, roleKey, borderRoleKey)
+  if frame and frame.SetBackdropColor then
+    local color = GetColor(roleKey)
+    frame:SetBackdropColor(color[1], color[2], color[3], color[4])
+  end
+  if borderRoleKey and frame and frame.SetBackdropBorderColor then
+    local borderColor = GetColor(borderRoleKey)
+    frame:SetBackdropBorderColor(borderColor[1], borderColor[2], borderColor[3], borderColor[4])
+  end
+end
+
+local function ColorToHex(color)
+  color = color or { 1, 1, 1, 1 }
+  local r = math.floor(((tonumber(color[1]) or 1) * 255) + 0.5)
+  local g = math.floor(((tonumber(color[2]) or 1) * 255) + 0.5)
+  local b = math.floor(((tonumber(color[3]) or 1) * 255) + 0.5)
+  return ("ff%02x%02x%02x"):format(r, g, b)
+end
+
+local function ApplyColorRefresh()
+  if WSGH.UI and WSGH.UI.Settings and WSGH.UI.Settings.RefreshColorControls then
+    WSGH.UI.Settings.RefreshColorControls()
+  end
+  if WSGH.UI and WSGH.UI.RefreshColors then
+    WSGH.UI.RefreshColors()
+  end
+  if WSGH.UI and WSGH.UI.Render then
+    WSGH.UI.Render()
+  end
+  if WSGH.UI and WSGH.UI.Shopping and WSGH.UI.Shopping.UpdateShoppingList then
+    WSGH.UI.Shopping.UpdateShoppingList()
+  end
+  if WSGH.UI and WSGH.UI.Highlight and WSGH.UI.Highlight.Refresh then
+    WSGH.UI.Highlight.Refresh()
+  end
+  if C_Timer and C_Timer.After then
+    C_Timer.After(0, function()
+      if WSGH.UI and WSGH.UI.Settings and WSGH.UI.Settings.RefreshColorControls then
+        WSGH.UI.Settings.RefreshColorControls()
+      end
+      if WSGH.UI and WSGH.UI.RefreshColors then
+        WSGH.UI.RefreshColors()
+      end
+    end)
+  end
 end
 
 local function CreateTaskTypeLookup()
@@ -229,11 +313,9 @@ local function CreateTaskPrioritySection(parent, anchor)
         row.label:SetText(taskType.label or key)
 
         if draggingKey == key then
-          row:SetBackdropColor(0.2, 0.32, 0.42, 0.85)
-          row:SetBackdropBorderColor(0.95, 0.85, 0.25, 1)
+          SetFrameBackdropColor(row, "settings.dragRowBackground", "settings.dragRowBorder")
         else
-          row:SetBackdropColor(0.03, 0.03, 0.03, 0.45)
-          row:SetBackdropBorderColor(0.35, 0.35, 0.35, 1)
+          SetFrameBackdropColor(row, "settings.idleRowBackground", "settings.idleRowBorder")
         end
 
         row:Show()
@@ -326,6 +408,550 @@ local function CreateTaskPrioritySection(parent, anchor)
   return section
 end
 
+local function ColorsMatch(a, b)
+  if type(a) ~= "table" or type(b) ~= "table" then return false end
+  for i = 1, 4 do
+    if math.abs((tonumber(a[i]) or 0) - (tonumber(b[i]) or 0)) > 0.001 then
+      return false
+    end
+  end
+  return true
+end
+
+local function IsColorCustomized(roleKey)
+  local preferences = GetPreferences()
+  return preferences
+    and type(preferences.colors) == "table"
+    and type(preferences.colors[roleKey]) == "table"
+    or false
+end
+
+local function SetSwatchColor(texture, color)
+  if not texture then return end
+  color = color or { 1, 1, 1, 1 }
+  texture:SetColorTexture(color[1] or 1, color[2] or 1, color[3] or 1, color[4] or 1)
+end
+
+local function FindPresetForColor(color)
+  for _, preset in ipairs(COLOR_PRESETS) do
+    if preset.color and ColorsMatch(color, preset.color) then
+      return preset.text, preset.value
+    end
+  end
+  return "Custom", "CUSTOM"
+end
+
+local function GetPresetByValue(value)
+  for _, preset in ipairs(COLOR_PRESETS) do
+    if preset.value == value then
+      return preset
+    end
+  end
+  return nil
+end
+
+local function FormatColorPresetText(preset)
+  if not (preset and preset.color) then
+    return preset and preset.text or ""
+  end
+
+  local isBlack = ColorsMatch(preset.color, { 0, 0, 0, 1 })
+  local swatch
+  if isBlack then
+    swatch = "|cffd0d0d0[|r|cff000000#|r|cffd0d0d0]|r"
+  else
+    swatch = "|c" .. ColorToHex(preset.color) .. "[#]|r"
+  end
+  return swatch .. " " .. preset.text
+end
+
+local function GetSelectedColorPreset(roleKey)
+  if not IsColorCustomized(roleKey) then
+    return "Default", "DEFAULT"
+  end
+  return FindPresetForColor(GetColor(roleKey))
+end
+
+local function ShouldShowColorPreset(roleKey, preset)
+  if preset and preset.customPicker then
+    return true
+  end
+  if not (preset and preset.color) then
+    return true
+  end
+  local defaultColor = WSGH.Util and WSGH.Util.GetDefaultColor and WSGH.Util.GetDefaultColor(roleKey) or nil
+  if defaultColor and ColorsMatch(defaultColor, preset.color) then
+    return false
+  end
+  return true
+end
+
+local function RefreshColorPreview()
+  if colorPreview.buttonDefault and WSGH.Util and WSGH.Util.ApplyButtonTextColor then
+    WSGH.Util.ApplyButtonTextColor(colorPreview.buttonDefault, "button.defaultText")
+  end
+  if colorPreview.buttonReforge and WSGH.Util and WSGH.Util.ApplyButtonTextColor then
+    WSGH.Util.ApplyButtonTextColor(colorPreview.buttonReforge, "button.reforgeText")
+  end
+  if colorPreview.buttonDone and WSGH.Util and WSGH.Util.ApplyButtonTextColor then
+    WSGH.Util.ApplyButtonTextColor(colorPreview.buttonDone, "button.doneText")
+  end
+  if colorPreview.buttonDisabled and WSGH.Util and WSGH.Util.ApplyButtonTextColor then
+    WSGH.Util.ApplyButtonTextColor(colorPreview.buttonDisabled, "button.purchaseText")
+  end
+  if colorPreview.previewButton and WSGH.Util and WSGH.Util.ApplyButtonTextColor then
+    WSGH.Util.ApplyButtonTextColor(colorPreview.previewButton, "button.defaultText")
+  end
+  SetSwatchColor(colorPreview.windowBackground, GetColor("window.background"))
+  SetSwatchColor(colorPreview.reminderBackground, GetColor("window.reminderBackground"))
+  SetFontColor(colorPreview.windowBackgroundLabel, "text.normal")
+  SetFontColor(colorPreview.reminderBackgroundLabel, "text.normal")
+  if colorPreview.highlightTarget and WSGH.UI and WSGH.UI.Highlight and WSGH.UI.Highlight.ApplyPreview then
+    WSGH.UI.Highlight.ApplyPreview(colorPreview.highlightTarget, "1")
+  end
+end
+
+function WSGH.UI.Settings.RefreshColorControls()
+  for _, row in ipairs(colorRows) do
+    local roleKey = row.roleKey
+    local color = GetColor(roleKey)
+    SetSwatchColor(row.swatchTexture, color)
+    if row.dropdown then
+      local text, selectedValue = GetSelectedColorPreset(roleKey)
+      local selectedPreset = GetPresetByValue(selectedValue)
+      UIDropDownMenu_SetText(row.dropdown, selectedPreset and FormatColorPresetText(selectedPreset) or text)
+      UIDropDownMenu_SetSelectedValue(row.dropdown, selectedValue)
+    end
+    if row.reset then
+      row.reset:SetEnabled(IsColorCustomized(roleKey))
+    end
+  end
+  if colorResetAllButton and WSGH.Util and WSGH.Util.HasCustomColors then
+    colorResetAllButton:SetEnabled(WSGH.Util.HasCustomColors())
+  end
+  RefreshColorPreview()
+end
+
+local function SetRoleColor(roleKey, color)
+  if WSGH.Util and WSGH.Util.SetColor then
+    WSGH.Util.SetColor(roleKey, color)
+  end
+  WSGH.UI.Settings.RefreshColorControls()
+  ApplyColorRefresh()
+end
+
+local function ResetRoleColor(roleKey)
+  if WSGH.Util and WSGH.Util.ResetColor then
+    WSGH.Util.ResetColor(roleKey)
+  end
+  WSGH.UI.Settings.RefreshColorControls()
+  ApplyColorRefresh()
+end
+
+local function OpenColorPicker(roleKey)
+  if not ColorPickerFrame then
+    return
+  end
+
+  local color = GetColor(roleKey)
+  local previous = { color[1], color[2], color[3], color[4] }
+  local wasCustomized = IsColorCustomized(roleKey)
+  local function CommitPickerColor()
+    local r, g, b = ColorPickerFrame:GetColorRGB()
+    local opacity = OpacitySliderFrame and OpacitySliderFrame.GetValue and OpacitySliderFrame:GetValue() or 0
+    local a = 1 - (tonumber(opacity) or 0)
+    SetRoleColor(roleKey, { r, g, b, a })
+  end
+
+  local function RestorePreviousColor()
+    if wasCustomized then
+      SetRoleColor(roleKey, previous)
+    else
+      ResetRoleColor(roleKey)
+    end
+  end
+
+  ColorPickerFrame.func = CommitPickerColor
+  ColorPickerFrame.opacityFunc = CommitPickerColor
+  ColorPickerFrame.cancelFunc = RestorePreviousColor
+  if ColorPickerFrame.SetupColorPickerAndShow then
+    ColorPickerFrame:SetupColorPickerAndShow({
+      r = color[1],
+      g = color[2],
+      b = color[3],
+      opacity = 1 - (tonumber(color[4]) or 1),
+      hasOpacity = true,
+      swatchFunc = CommitPickerColor,
+      opacityFunc = CommitPickerColor,
+      cancelFunc = ColorPickerFrame.cancelFunc,
+    })
+    return
+  end
+  ColorPickerFrame.previousValues = previous
+  ColorPickerFrame.hasOpacity = true
+  ColorPickerFrame.opacity = 1 - (tonumber(color[4]) or 1)
+  ColorPickerFrame:SetColorRGB(color[1], color[2], color[3])
+  ColorPickerFrame:Hide()
+  ColorPickerFrame:Show()
+end
+
+local function GetSettingsScrollLayout()
+  return WSGH.Const
+    and WSGH.Const.UI
+    and WSGH.Const.UI.settings
+    and WSGH.Const.UI.settings.scroll
+    or {}
+end
+
+local function UpdateSettingsScrollHeight()
+  if not settingsScrollContent then return end
+
+  local layout = GetSettingsScrollLayout()
+  local minHeight = tonumber(layout.minChildHeight) or 760
+  local bottomPadding = tonumber(layout.bottomPadding) or 36
+  local contentTop = settingsScrollContent.GetTop and settingsScrollContent:GetTop() or nil
+  local measuredHeight = 0
+
+  if contentTop then
+    for _, child in ipairs({ settingsScrollContent:GetChildren() }) do
+      if child and child.IsShown and child:IsShown() and child.GetBottom then
+        local childBottom = child:GetBottom()
+        if childBottom then
+          measuredHeight = math.max(measuredHeight, contentTop - childBottom + bottomPadding)
+        end
+      end
+    end
+  end
+
+  local nextHeight = math.max(minHeight, math.ceil(measuredHeight))
+  settingsScrollContentHeight = nextHeight
+  settingsScrollContent:SetHeight(nextHeight)
+
+  if settingsScrollFrame and settingsScrollFrame.GetVerticalScroll then
+    local viewHeight = settingsScrollFrame.GetHeight and settingsScrollFrame:GetHeight() or 0
+    local maxScroll = math.max(0, nextHeight - viewHeight)
+    local current = settingsScrollFrame:GetVerticalScroll() or 0
+    if current > maxScroll then
+      settingsScrollFrame:SetVerticalScroll(maxScroll)
+      if settingsScrollFrame.ScrollBar and settingsScrollFrame.ScrollBar.SetValue then
+        settingsScrollFrame.ScrollBar:SetValue(maxScroll)
+      end
+    end
+  end
+end
+
+local function CreatePreviewLabel(parent, text, template, x, y)
+  local label = parent:CreateFontString(nil, "OVERLAY", template or "GameFontHighlightSmall")
+  label:SetPoint("TOPLEFT", parent, "TOPLEFT", x, y)
+  label:SetText(text)
+  return label
+end
+
+local function CreatePreviewBlock(parent, x, y, width, height)
+  local block = parent:CreateTexture(nil, "BACKGROUND")
+  block:SetPoint("TOPLEFT", parent, "TOPLEFT", x, y)
+  block:SetSize(width, height)
+  return block
+end
+
+local function CreatePreviewSwatch(parent, x, y, width, height)
+  local swatch = CreatePreviewBlock(parent, x, y, width, height)
+  swatch:SetDrawLayer("ARTWORK")
+  return swatch
+end
+
+local function CreatePreviewButton(parent, text, x, y, width, height, enabled)
+  local button = CreateFrame("Button", nil, parent, "UIPanelButtonTemplate")
+  button:SetPoint("TOPLEFT", parent, "TOPLEFT", x, y)
+  button:SetSize(width, height)
+  button:SetText(text)
+  button:SetEnabled(enabled ~= false)
+  button:EnableMouse(false)
+  return button
+end
+
+local function ShowColorRoleTooltip(owner, role, extraLine)
+  if not (owner and role and role.description) then return end
+  GameTooltip:SetOwner(owner, "ANCHOR_RIGHT")
+  GameTooltip:SetText(role.label or role.key or "Color", 1, 1, 1)
+  GameTooltip:AddLine(role.description, nil, nil, nil, true)
+  if extraLine then
+    GameTooltip:AddLine(" ")
+    GameTooltip:AddLine(extraLine, nil, nil, nil, true)
+  end
+  GameTooltip:Show()
+end
+
+local function CreateColorHelpButton(parent, role, rowLayout, y)
+  if not (role and role.description) then return nil end
+
+  local help = CreateFrame("Button", nil, parent)
+  help:SetPoint(
+    "TOPLEFT",
+    parent,
+    "TOPLEFT",
+    tonumber(rowLayout.helpX) or 166,
+    y + (tonumber(rowLayout.helpYOffset) or -3)
+  )
+  help:SetSize(tonumber(rowLayout.helpWidth) or 14, tonumber(rowLayout.helpHeight) or 14)
+
+  local text = help:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+  text:SetAllPoints(help)
+  text:SetJustifyH("CENTER")
+  text:SetJustifyV("MIDDLE")
+  text:SetText("?")
+  help:SetScript("OnEnter", function(self)
+    ShowColorRoleTooltip(self, role)
+  end)
+  help:SetScript("OnLeave", GameTooltip_Hide)
+  return help
+end
+
+local function CreateColorPreview(parent)
+  local layout = WSGH.Const and WSGH.Const.UI and WSGH.Const.UI.settings and WSGH.Const.UI.settings.colors or {}
+  local previewLayout = layout.preview or {}
+  local preview = CreateFrame("Frame", nil, parent, "BackdropTemplate")
+  preview:SetPoint("TOPLEFT", parent, "TOPLEFT", 0, tonumber(previewLayout.yOffset) or -34)
+  preview:SetSize(tonumber(previewLayout.width) or 540, tonumber(previewLayout.height) or 112)
+  preview:SetBackdrop({
+    bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile = true,
+    tileSize = 16,
+    edgeSize = 10,
+    insets = { left = 2, right = 2, top = 2, bottom = 2 },
+  })
+  preview:SetBackdropColor(0.03, 0.03, 0.03, 0.55)
+  preview:SetBackdropBorderColor(0.35, 0.35, 0.35, 1)
+
+  colorPreview.buttonDefault = CreatePreviewButton(preview, "Socket", 10, -12, 70, 20, true)
+  colorPreview.buttonReforge = CreatePreviewButton(preview, "Reforge*", 88, -12, 82, 20, true)
+  colorPreview.buttonDone = CreatePreviewButton(preview, "Done", 178, -12, 70, 20, false)
+  colorPreview.buttonDisabled = CreatePreviewButton(preview, "Purchase", 256, -12, 82, 20, false)
+  colorPreview.previewButton = colorPreview.buttonDefault
+
+  colorPreview.highlightTarget = CreateFrame("Frame", nil, preview, "BackdropTemplate")
+  colorPreview.highlightTarget:SetPoint("TOPLEFT", preview, "TOPLEFT", 370, -8)
+  colorPreview.highlightTarget:SetSize(28, 28)
+  colorPreview.highlightTarget:SetBackdrop({
+    bgFile = "Interface\\Buttons\\WHITE8x8",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile = false,
+    edgeSize = 8,
+    insets = { left = 1, right = 1, top = 1, bottom = 1 },
+  })
+  colorPreview.highlightTarget:SetBackdropColor(0.08, 0.08, 0.08, 0.75)
+  colorPreview.highlightTarget:SetBackdropBorderColor(0.5, 0.5, 0.5, 1)
+
+  colorPreview.windowBackground = CreatePreviewSwatch(preview, 418, -12, 44, 20)
+  colorPreview.windowBackgroundLabel = CreatePreviewLabel(preview, "Main", "GameFontNormalSmall", 426, -15)
+  colorPreview.reminderBackground = CreatePreviewSwatch(preview, 474, -12, 48, 20)
+  colorPreview.reminderBackgroundLabel = CreatePreviewLabel(preview, "Note", "GameFontNormalSmall", 484, -15)
+
+  return preview
+end
+
+local function CreateColorSettingsSection(parent, anchor, xOffset, yOffset)
+  local layout = WSGH.Const and WSGH.Const.UI and WSGH.Const.UI.settings and WSGH.Const.UI.settings.colors or {}
+  local openWindowButtonLayout = layout.openWindowButton or {}
+  local resetAllButtonLayout = layout.resetAllButton or {}
+  local rowLayout = layout.row or {}
+  local section = CreateFrame("Frame", nil, parent)
+  colorSectionFrame = section
+  colorSectionHeight = tonumber(layout.height) or 760
+  section:SetPoint("TOPLEFT", anchor, "BOTTOMLEFT", xOffset or 0, yOffset or -12)
+  section:SetSize(tonumber(layout.width) or 560, colorSectionHeight)
+
+  local title = section:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+  title:SetPoint("TOPLEFT", section, "TOPLEFT", 0, 0)
+  title:SetText("Colors")
+
+  colorSectionContent = CreateFrame("Frame", nil, section)
+  colorSectionContent:SetPoint("TOPLEFT", section, "TOPLEFT", 0, 0)
+  colorSectionContent:SetSize(tonumber(layout.width) or 560, tonumber(layout.contentHeight) or 740)
+
+  local note = colorSectionContent:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+  note:SetPoint("TOPLEFT", colorSectionContent, "TOPLEFT", 0, -18)
+  note:SetWidth(tonumber(layout.noteWidth) or 520)
+  note:SetJustifyH("LEFT")
+  note:SetText("Swatches open the color picker. Dropdowns offer quick presets.")
+
+  CreateColorPreview(colorSectionContent)
+
+  colorResetAllButton = CreateFrame("Button", nil, section, "UIPanelButtonTemplate")
+  colorResetAllButton:SetSize(tonumber(resetAllButtonLayout.width) or 104, tonumber(resetAllButtonLayout.height) or 20)
+  colorResetAllButton:SetPoint(
+    "TOPRIGHT",
+    section,
+    "TOPRIGHT",
+    tonumber(resetAllButtonLayout.xOffset) or -16,
+    tonumber(resetAllButtonLayout.yOffset) or 2
+  )
+  colorResetAllButton:SetText("Reset all colors")
+  colorResetAllButton:SetScript("OnClick", function()
+    StaticPopup_Show("WSGH_RESET_ALL_COLORS")
+  end)
+
+  colorOpenWindowButton = CreateFrame("Button", nil, section, "UIPanelButtonTemplate")
+  colorOpenWindowButton:SetSize(tonumber(openWindowButtonLayout.width) or 92, tonumber(openWindowButtonLayout.height) or 20)
+  colorOpenWindowButton:SetPoint(
+    "TOPRIGHT",
+    section,
+    "TOPRIGHT",
+    tonumber(openWindowButtonLayout.xOffset) or -118,
+    tonumber(openWindowButtonLayout.yOffset) or 2
+  )
+  colorOpenWindowButton:SetText("Open window")
+  colorOpenWindowButton:SetScript("OnClick", function()
+    if WSGH.UI and WSGH.UI.Show then
+      WSGH.UI.Show()
+    end
+  end)
+  colorOpenWindowButton:SetScript("OnEnter", function(self)
+    GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+    GameTooltip:SetText("Open WSGH", 1, 1, 1)
+    GameTooltip:AddLine("Show the addon window so color changes can be previewed live.", nil, nil, nil, true)
+    GameTooltip:Show()
+  end)
+  colorOpenWindowButton:SetScript("OnLeave", GameTooltip_Hide)
+
+  local y = tonumber(rowLayout.topOffset) or -136
+  colorRows = {}
+  for _, group in ipairs(WSGH.Util.GetColorRoleGroups and WSGH.Util.GetColorRoleGroups() or {}) do
+    local heading = colorSectionContent:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    heading:SetPoint("TOPLEFT", colorSectionContent, "TOPLEFT", 0, y)
+    heading:SetText(group.heading or "")
+    y = y - (tonumber(rowLayout.headingGap) or 20)
+
+    for _, role in ipairs(group.roles or {}) do
+      local roleKey = role.key
+      local label = colorSectionContent:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+      label:SetPoint(
+        "TOPLEFT",
+        colorSectionContent,
+        "TOPLEFT",
+        tonumber(rowLayout.labelX) or 8,
+        y + (tonumber(rowLayout.labelYOffset) or -2)
+      )
+      label:SetWidth(tonumber(rowLayout.labelWidth) or 170)
+      label:SetJustifyH("LEFT")
+      label:SetText(role.label or roleKey)
+      CreateColorHelpButton(colorSectionContent, role, rowLayout, y)
+
+      local swatch = CreateFrame("Button", nil, colorSectionContent, "BackdropTemplate")
+      swatch:SetPoint("TOPLEFT", colorSectionContent, "TOPLEFT", tonumber(rowLayout.swatchX) or 184, y)
+      swatch:SetSize(tonumber(rowLayout.swatchWidth) or 22, tonumber(rowLayout.swatchHeight) or 18)
+      swatch:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        tile = false,
+        edgeSize = 8,
+        insets = { left = 1, right = 1, top = 1, bottom = 1 },
+      })
+      swatch:SetBackdropBorderColor(0.3, 0.3, 0.3, 1)
+      swatch.texture = swatch:CreateTexture(nil, "ARTWORK")
+      swatch.texture:SetPoint("TOPLEFT", swatch, "TOPLEFT", 3, -3)
+      swatch.texture:SetPoint("BOTTOMRIGHT", swatch, "BOTTOMRIGHT", -3, 3)
+      swatch:SetScript("OnClick", function()
+        OpenColorPicker(roleKey)
+      end)
+      if role.description then
+        swatch:SetScript("OnEnter", function(self)
+          ShowColorRoleTooltip(self, role)
+        end)
+        swatch:SetScript("OnLeave", GameTooltip_Hide)
+      end
+
+      local dropName = "WSGHColorPreset" .. tostring(#colorRows + 1)
+      local drop = CreateFrame("Frame", dropName, colorSectionContent, "UIDropDownMenuTemplate")
+      drop:SetPoint(
+        "TOPLEFT",
+        swatch,
+        "TOPRIGHT",
+        tonumber(rowLayout.dropdownOffsetX) or -10,
+        tonumber(rowLayout.dropdownOffsetY) or 2
+      )
+      UIDropDownMenu_SetWidth(drop, tonumber(rowLayout.dropdownWidth) or 112)
+      UIDropDownMenu_Initialize(drop, function(_, level)
+        local _, selectedValue = GetSelectedColorPreset(roleKey)
+        for _, preset in ipairs(COLOR_PRESETS) do
+          if ShouldShowColorPreset(roleKey, preset) then
+            local info = UIDropDownMenu_CreateInfo()
+            info.text = FormatColorPresetText(preset)
+            info.value = preset.value
+            info.isNotRadio = false
+            info.keepShownOnClick = false
+            info.func = function()
+              if preset.customPicker then
+                OpenColorPicker(roleKey)
+              elseif preset.value == "DEFAULT" then
+                ResetRoleColor(roleKey)
+              else
+                SetRoleColor(roleKey, preset.color)
+              end
+              if CloseDropDownMenus then
+                CloseDropDownMenus()
+              end
+            end
+            info.checked = selectedValue == preset.value
+            UIDropDownMenu_AddButton(info, level)
+          end
+        end
+      end)
+
+      local reset = CreateFrame("Button", nil, colorSectionContent, "UIPanelButtonTemplate")
+      reset:SetPoint(
+        "LEFT",
+        drop,
+        "RIGHT",
+        tonumber(rowLayout.resetOffsetX) or -6,
+        tonumber(rowLayout.resetOffsetY) or 0
+      )
+      reset:SetSize(tonumber(rowLayout.resetWidth) or 44, tonumber(rowLayout.resetHeight) or 20)
+      reset:SetText("Reset")
+      reset:SetScript("OnClick", function()
+        ResetRoleColor(roleKey)
+      end)
+
+      colorRows[#colorRows + 1] = {
+        roleKey = roleKey,
+        swatchTexture = swatch.texture,
+        dropdown = drop,
+        reset = reset,
+      }
+      y = y - (tonumber(rowLayout.rowHeight) or 24)
+    end
+    y = y - (tonumber(rowLayout.groupGap) or 4)
+  end
+  local sectionHeight = math.max(tonumber(layout.height) or 760, math.abs(y) + 24)
+  colorSectionHeight = sectionHeight
+  section:SetHeight(sectionHeight)
+  colorSectionContent:SetHeight(sectionHeight - 20)
+
+  if not StaticPopupDialogs["WSGH_RESET_ALL_COLORS"] then
+    StaticPopupDialogs["WSGH_RESET_ALL_COLORS"] = {
+      text = "Reset all WowSims Gear Helper colors to their defaults?",
+      button1 = "Reset",
+      button2 = "Cancel",
+      OnAccept = function()
+        if WSGH.Util and WSGH.Util.ResetAllColors then
+          WSGH.Util.ResetAllColors()
+        end
+        WSGH.UI.Settings.RefreshColorControls()
+        ApplyColorRefresh()
+      end,
+      timeout = 0,
+      whileDead = true,
+      hideOnEscape = true,
+      preferredIndex = 3,
+    }
+  end
+
+  UpdateSettingsScrollHeight()
+  WSGH.UI.Settings.RefreshColorControls()
+  return section
+end
+
 local function BuildOptionsPanel()
   if optionsPanel then return end
 
@@ -333,28 +959,58 @@ local function BuildOptionsPanel()
   optionsPanel = CreateFrame("Frame", "WowSimsGearHelperOptions", InterfaceOptionsFramePanelContainer or UIParent)
   optionsPanel.name = categoryName
 
-  local title = optionsPanel:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
-  title:SetPoint("TOPLEFT", 16, -16)
+  local scrollLayout = GetSettingsScrollLayout()
+  local optionsScroll = CreateFrame("ScrollFrame", "WowSimsGearHelperOptionsScroll", optionsPanel, "UIPanelScrollFrameTemplate")
+  settingsScrollFrame = optionsScroll
+  optionsScroll:SetPoint("TOPLEFT", optionsPanel, "TOPLEFT", 0, 0)
+  optionsScroll:SetPoint("BOTTOMRIGHT", optionsPanel, "BOTTOMRIGHT", -(tonumber(scrollLayout.rightInset) or 28), 0)
+  optionsScroll:EnableMouseWheel(true)
+
+  local optionsContent = CreateFrame("Frame", "WowSimsGearHelperOptionsContent", optionsScroll)
+  settingsScrollContent = optionsContent
+  settingsScrollContentHeight = tonumber(scrollLayout.minChildHeight) or 760
+  optionsContent:SetSize(
+    tonumber(scrollLayout.childWidth) or 640,
+    settingsScrollContentHeight
+  )
+  optionsScroll:SetScrollChild(optionsContent)
+  optionsScroll:SetScript("OnMouseWheel", function(self, delta)
+    local childHeight = settingsScrollContent and settingsScrollContent:GetHeight() or 0
+    local viewHeight = self.GetHeight and self:GetHeight() or 0
+    local maxScroll = math.max(0, childHeight - viewHeight)
+    local current = self.GetVerticalScroll and self:GetVerticalScroll() or 0
+    local step = tonumber(scrollLayout.mouseWheelStep) or 36
+    local nextScroll = current - ((tonumber(delta) or 0) * step)
+    if nextScroll < 0 then nextScroll = 0 end
+    if nextScroll > maxScroll then nextScroll = maxScroll end
+    self:SetVerticalScroll(nextScroll)
+    if self.ScrollBar and self.ScrollBar.SetValue then
+      self.ScrollBar:SetValue(nextScroll)
+    end
+  end)
+
+  local title = optionsContent:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+  title:SetPoint("TOPLEFT", optionsContent, "TOPLEFT", 16, -16)
   title:SetText(categoryName)
 
-  local desc = optionsPanel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+  local desc = optionsContent:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
   desc:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -8)
   desc:SetText("Preferences")
 
   local addonVersion = WSGH.Util and WSGH.Util.GetAddonVersion and WSGH.Util.GetAddonVersion() or (WSGH.VERSION or "unknown")
-  local versionText = optionsPanel:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+  local versionText = optionsContent:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
   versionText:SetPoint("TOPLEFT", desc, "BOTTOMLEFT", 0, -4)
   versionText:SetText(("Version: %s"):format(tostring(addonVersion)))
 
   local preferences = GetPreferences() or {}
-  CreateTaskPrioritySection(optionsPanel, versionText)
+  CreateTaskPrioritySection(optionsContent, versionText)
 
-  local persistCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
+  local persistCheck = CreateFrame("CheckButton", nil, optionsContent, "ChatConfigCheckButtonTemplate")
   persistCheck:SetPoint("TOPLEFT", versionText, "BOTTOMLEFT", 0, -8)
   persistCheck.Text:SetText("Save last import")
   persistCheck:SetChecked(preferences.persistImports or false)
 
-  local restoreReminderCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
+  local restoreReminderCheck = CreateFrame("CheckButton", nil, optionsContent, "ChatConfigCheckButtonTemplate")
   restoreReminderCheck:SetPoint("TOPLEFT", persistCheck, "BOTTOMLEFT", 18, -4)
   restoreReminderCheck.Text:SetText("Show manual reforge reminder on restore")
   restoreReminderCheck:SetChecked(preferences.showReforgeReminderOnRestore == true)
@@ -362,7 +1018,11 @@ local function BuildOptionsPanel()
   local function RefreshRestoreReminderCheck()
     local enabled = persistCheck:GetChecked() == true
     restoreReminderCheck:SetEnabled(enabled)
-    restoreReminderCheck.Text:SetTextColor(enabled and 1 or 0.5, enabled and 1 or 0.5, enabled and 1 or 0.5)
+    if enabled then
+      SetFontColor(restoreReminderCheck.Text, "text.normal")
+    else
+      SetFontColor(restoreReminderCheck.Text, "text.muted")
+    end
   end
 
   persistCheck:SetScript("OnClick", function(self)
@@ -401,7 +1061,7 @@ local function BuildOptionsPanel()
   end)
   restoreReminderCheck:SetScript("OnLeave", GameTooltip_Hide)
 
-  local minimapCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
+  local minimapCheck = CreateFrame("CheckButton", nil, optionsContent, "ChatConfigCheckButtonTemplate")
   minimapCheck:SetPoint("TOPLEFT", restoreReminderCheck, "BOTTOMLEFT", -18, -6)
   minimapCheck.Text:SetText("Show minimap icon")
   minimapCheck:SetChecked(not (preferences.minimap and preferences.minimap.hide))
@@ -422,28 +1082,8 @@ local function BuildOptionsPanel()
   end)
   minimapCheck:SetScript("OnLeave", GameTooltip_Hide)
 
-  local opaqueBackgroundCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
-  opaqueBackgroundCheck:SetPoint("TOPLEFT", minimapCheck, "BOTTOMLEFT", 0, -6)
-  opaqueBackgroundCheck.Text:SetText("Use opaque background for all windows")
-  opaqueBackgroundCheck:SetChecked(preferences.useOpaqueBackgroundForAllWindows == true)
-  opaqueBackgroundCheck:SetScript("OnClick", function(self)
-    local preferencesTable = GetPreferences()
-    if not preferencesTable then return end
-    preferencesTable.useOpaqueBackgroundForAllWindows = self:GetChecked() and true or false
-    if WSGH.UI and WSGH.UI.RefreshWindowBackgrounds then
-      WSGH.UI.RefreshWindowBackgrounds()
-    end
-  end)
-  opaqueBackgroundCheck:SetScript("OnEnter", function(self)
-    GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-    GameTooltip:SetText("Use opaque background for all windows", 1, 1, 1)
-    GameTooltip:AddLine("Apply the solid dark help/import background style to the main addon and shopping windows too.", nil, nil, nil, true)
-    GameTooltip:Show()
-  end)
-  opaqueBackgroundCheck:SetScript("OnLeave", GameTooltip_Hide)
-
-  local useValorCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
-  useValorCheck:SetPoint("TOPLEFT", opaqueBackgroundCheck, "BOTTOMLEFT", 0, -6)
+  local useValorCheck = CreateFrame("CheckButton", nil, optionsContent, "ChatConfigCheckButtonTemplate")
+  useValorCheck:SetPoint("TOPLEFT", minimapCheck, "BOTTOMLEFT", 0, -6)
   useValorCheck.Text:SetText("Use Valor for upgrades")
   useValorCheck:SetChecked(preferences.useValorForUpgrades == true)
   useValorCheck:SetScript("OnClick", function(self)
@@ -464,7 +1104,7 @@ local function BuildOptionsPanel()
   end)
   useValorCheck:SetScript("OnLeave", GameTooltip_Hide)
 
-  local reforgeReminderCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
+  local reforgeReminderCheck = CreateFrame("CheckButton", nil, optionsContent, "ChatConfigCheckButtonTemplate")
   reforgeReminderCheck:SetPoint("TOPLEFT", useValorCheck, "BOTTOMLEFT", 0, -6)
   reforgeReminderCheck.Text:SetText("Show manual reforge reminder after import")
   reforgeReminderCheck:SetChecked(preferences.showReforgeReminderAfterImport ~= false)
@@ -487,7 +1127,7 @@ local function BuildOptionsPanel()
   end)
   reforgeReminderCheck:SetScript("OnLeave", GameTooltip_Hide)
 
-  local reforgeLiteSyncCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
+  local reforgeLiteSyncCheck = CreateFrame("CheckButton", nil, optionsContent, "ChatConfigCheckButtonTemplate")
   reforgeLiteSyncCheck:SetPoint("TOPLEFT", reforgeReminderCheck, "BOTTOMLEFT", 0, -6)
   reforgeLiteSyncCheck.Text:SetText("Sync imports to ReforgeLite")
   reforgeLiteSyncCheck:SetChecked(preferences.syncImportsToReforgeLite ~= false)
@@ -504,7 +1144,7 @@ local function BuildOptionsPanel()
   end)
   reforgeLiteSyncCheck:SetScript("OnLeave", GameTooltip_Hide)
 
-  local minimizeAtForgeCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
+  local minimizeAtForgeCheck = CreateFrame("CheckButton", nil, optionsContent, "ChatConfigCheckButtonTemplate")
   minimizeAtForgeCheck:SetPoint("TOPLEFT", reforgeLiteSyncCheck, "BOTTOMLEFT", 0, -6)
   minimizeAtForgeCheck.Text:SetText("Minimize WSGH at Reforge NPC")
   minimizeAtForgeCheck:SetChecked(preferences.minimizeWindowAtReforgeNpc ~= false)
@@ -521,7 +1161,7 @@ local function BuildOptionsPanel()
   end)
   minimizeAtForgeCheck:SetScript("OnLeave", GameTooltip_Hide)
 
-  local restoreAfterForgeCheck = CreateFrame("CheckButton", nil, optionsPanel, "ChatConfigCheckButtonTemplate")
+  local restoreAfterForgeCheck = CreateFrame("CheckButton", nil, optionsContent, "ChatConfigCheckButtonTemplate")
   restoreAfterForgeCheck:SetPoint("TOPLEFT", minimizeAtForgeCheck, "BOTTOMLEFT", 0, -6)
   restoreAfterForgeCheck.Text:SetText("Restore WSGH after Reforge NPC closes")
   restoreAfterForgeCheck:SetChecked(preferences.restoreWindowAfterReforgeNpc == true)
@@ -538,11 +1178,11 @@ local function BuildOptionsPanel()
   end)
   restoreAfterForgeCheck:SetScript("OnLeave", GameTooltip_Hide)
 
-  local highlightLabel = optionsPanel:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+  local highlightLabel = optionsContent:CreateFontString(nil, "OVERLAY", "GameFontNormal")
   highlightLabel:SetPoint("TOPLEFT", restoreAfterForgeCheck, "BOTTOMLEFT", 0, -16)
   highlightLabel:SetText("Highlight style:")
 
-  local highlightDrop = CreateFrame("Frame", "WSGHHighlightStyle", optionsPanel, "UIDropDownMenuTemplate")
+  local highlightDrop = CreateFrame("Frame", "WSGHHighlightStyle", optionsContent, "UIDropDownMenuTemplate")
   highlightDrop:SetPoint("TOPLEFT", highlightLabel, "BOTTOMLEFT", -16, -4)
   UIDropDownMenu_SetWidth(highlightDrop, 205)
   UIDropDownMenu_SetButtonWidth(highlightDrop, 205)
@@ -562,6 +1202,9 @@ local function BuildOptionsPanel()
         preferencesTable.highlightStyle = opt.value
         if WSGH.UI and WSGH.UI.Highlight and WSGH.UI.Highlight.Refresh then
           WSGH.UI.Highlight.Refresh()
+        end
+        if WSGH.UI and WSGH.UI.Settings and WSGH.UI.Settings.RefreshColorControls then
+          WSGH.UI.Settings.RefreshColorControls()
         end
       end
       info.checked = (opt.value == current)
@@ -588,7 +1231,7 @@ local function BuildOptionsPanel()
   UIDropDownMenu_SetSelectedValue(highlightDrop, highlightInitial)
   RefreshRestoreReminderCheck()
 
-  local tinkerLabel = optionsPanel:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+  local tinkerLabel = optionsContent:CreateFontString(nil, "OVERLAY", "GameFontNormal")
   tinkerLabel:SetPoint("TOPLEFT", highlightDrop, "BOTTOMLEFT", 16, -12)
   tinkerLabel:SetText("Default tinker:")
   tinkerLabel:SetShown(WSGH.Diff and WSGH.Diff.Engine and WSGH.Diff.Engine.ENABLE_TINKERS == true)
@@ -620,7 +1263,7 @@ local function BuildOptionsPanel()
     }
   }
 
-  local dropdownAnchor = CreateFrame("Frame", nil, optionsPanel)
+  local dropdownAnchor = CreateFrame("Frame", nil, optionsContent)
   dropdownAnchor:SetPoint("TOPLEFT", tinkerLabel, "BOTTOMLEFT", 0, -6)
   dropdownAnchor:SetSize(1, 1)
   dropdownAnchor:SetShown(WSGH.Diff and WSGH.Diff.Engine and WSGH.Diff.Engine.ENABLE_TINKERS == true)
@@ -628,12 +1271,12 @@ local function BuildOptionsPanel()
 
   local function CreateTinkerDropdown(name, labelText, slotId, options)
     local showTinkers = (WSGH.Diff and WSGH.Diff.Engine and WSGH.Diff.Engine.ENABLE_TINKERS == true)
-    local label = optionsPanel:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    local label = optionsContent:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     label:SetPoint("TOPLEFT", dropdownAnchor, "TOPLEFT", 0, nextYOffset)
     label:SetText(labelText)
     label:SetShown(showTinkers)
 
-    local drop = CreateFrame("Frame", name, optionsPanel, "UIDropDownMenuTemplate")
+    local drop = CreateFrame("Frame", name, optionsContent, "UIDropDownMenuTemplate")
     drop:SetPoint("TOPLEFT", dropdownAnchor, "TOPLEFT", -16, nextYOffset - 18)
     UIDropDownMenu_SetWidth(drop, 200)
     drop:SetShown(showTinkers)
@@ -684,6 +1327,22 @@ local function BuildOptionsPanel()
   CreateTinkerDropdown("WSGHDefaultTinkerCloak", "Cloak", 15, mopTinkerOptions.cloak)
   CreateTinkerDropdown("WSGHDefaultTinkerGloves", "Gloves", 10, mopTinkerOptions.gloves)
   CreateTinkerDropdown("WSGHDefaultTinkerBelt", "Belt", 6, mopTinkerOptions.belt)
+
+  if WSGH.Diff and WSGH.Diff.Engine and WSGH.Diff.Engine.ENABLE_TINKERS == true then
+    CreateColorSettingsSection(optionsContent, dropdownAnchor, 0, nextYOffset - 8)
+  else
+    CreateColorSettingsSection(optionsContent, highlightDrop, 16, -12)
+  end
+  UpdateSettingsScrollHeight()
+  if C_Timer and C_Timer.After then
+    C_Timer.After(0, UpdateSettingsScrollHeight)
+  end
+  optionsPanel:SetScript("OnShow", function()
+    UpdateSettingsScrollHeight()
+    if C_Timer and C_Timer.After then
+      C_Timer.After(0, UpdateSettingsScrollHeight)
+    end
+  end)
 
   if Settings and Settings.RegisterAddOnCategory then
     optionsCategory = Settings.RegisterCanvasLayoutCategory(optionsPanel, categoryName)

--- a/UI/Shopping.lua
+++ b/UI/Shopping.lua
@@ -6,6 +6,19 @@ local DEBUG_SHOPPING = false
 local jpHighlightItemId = nil
 local IsAuctionHouseOpen
 
+local function GetColor(roleKey)
+  if WSGH.Util and WSGH.Util.GetColor then
+    return WSGH.Util.GetColor(roleKey)
+  end
+  return { 1, 1, 1, 1 }
+end
+
+local function SetFontColor(fontString, roleKey)
+  if not (fontString and fontString.SetTextColor) then return end
+  local color = GetColor(roleKey)
+  fontString:SetTextColor(color[1], color[2], color[3], color[4])
+end
+
 local function DebugShopping(msg)
   if not DEBUG_SHOPPING then return end
   if WSGH and WSGH.Util and WSGH.Util.Print then
@@ -1032,7 +1045,7 @@ function WSGH.UI.Shopping.UpdateShoppingList()
           entry.icon.itemId = nil
           entry.text:SetText(data.header or "")
           entry.text:SetFontObject("GameFontHighlightSmall")
-          entry.text:SetTextColor(1, 0.82, 0, 1)
+          SetFontColor(entry.text, "shopping.header")
           if entry.strike then entry.strike:Hide() end
           entry.count:SetText("")
           if entry.countIcon then
@@ -1069,10 +1082,10 @@ function WSGH.UI.Shopping.UpdateShoppingList()
             entry.icon.itemId = nil
             entry.text:SetFontObject("GameFontNormalSmall")
             entry.text:SetText(("%s: %d/%d | Missing: %d (%s)"):format(currencyShort, currentValue, currencyCap, currencyMissing, upgradesLabel))
-            entry.text:SetTextColor(1, 1, 1, 1)
+            SetFontColor(entry.text, "shopping.itemText")
             if entry.strike then entry.strike:Hide() end
             entry.count:SetText("")
-            entry.count:SetTextColor(1, 1, 1, 1)
+            SetFontColor(entry.count, "shopping.itemText")
             if entry.countIcon then
               local _, _, _, _, _, _, _, _, _, commIcon = GetItemInfo(actionItemId)
               if not commIcon then
@@ -1190,9 +1203,9 @@ function WSGH.UI.Shopping.UpdateShoppingList()
             local purchaseTarget = tonumber(data.count) or 0
             local isFullyPurchased = (tonumber(data.bought) or 0) >= purchaseTarget and purchaseTarget > 0
             if isFullyPurchased then
-              entry.text:SetTextColor(0.72, 0.72, 0.72, 1)
+              SetFontColor(entry.text, "shopping.completedText")
             else
-              entry.text:SetTextColor(1, 1, 1, 1)
+              SetFontColor(entry.text, "shopping.itemText")
             end
             if entry.strike then entry.strike:Hide() end
             local totalNeeded = purchaseTarget
@@ -1249,9 +1262,9 @@ function WSGH.UI.Shopping.UpdateShoppingList()
               end
             end)
             if isFullyPurchased then
-              entry.count:SetTextColor(0.72, 0.72, 0.72, 1)
+              SetFontColor(entry.count, "shopping.completedText")
             else
-              entry.count:SetTextColor(1, 1, 1, 1)
+              SetFontColor(entry.count, "shopping.itemText")
             end
             entry.itemId = data.itemId
             entry:SetScript("OnEnter", function(self)

--- a/Util.lua
+++ b/Util.lua
@@ -187,7 +187,6 @@ function WSGH.Util.GetPreferences()
   if prefs.savedImportText == nil then prefs.savedImportText = nil end
   if prefs.showReforgeReminderAfterImport == nil then prefs.showReforgeReminderAfterImport = true end
   if prefs.showReforgeReminderOnRestore == nil then prefs.showReforgeReminderOnRestore = false end
-  if prefs.useOpaqueBackgroundForAllWindows == nil then prefs.useOpaqueBackgroundForAllWindows = false end
   if prefs.tinkers == nil then prefs.tinkers = {} end
   if prefs.highlightStyle == nil then
     prefs.highlightStyle = (WSGH.Const and WSGH.Const.HIGHLIGHT and WSGH.Const.HIGHLIGHT.style) or "label"
@@ -204,26 +203,197 @@ function WSGH.Util.GetPreferences()
   if prefs.useValorForUpgrades == nil then
     prefs.useValorForUpgrades = (prefs.upgradeCurrency == "VALOR")
   end
+  if type(prefs.colors) ~= "table" then
+    prefs.colors = {}
+  end
   prefs.taskPriorityOrder = WSGH.Util.NormalizeTaskPriorityOrder(prefs.taskPriorityOrder)
   WSGH.DB = _G.WowSimsGearHelperDB
   return prefs
 end
 
-local OPAQUE_WINDOW_COLOR = { 0.0235, 0.0314, 0.0510, 1 }
-
-function WSGH.Util.ShouldUseOpaqueWindowBackground(windowKind)
-  if windowKind == "help" or windowKind == "import" then
-    return true
+local function ClampColorChannel(value, fallback)
+  local n = tonumber(value)
+  if n == nil then
+    n = tonumber(fallback) or 0
   end
-
-  local prefs = WSGH.Util.GetPreferences()
-  return prefs and prefs.useOpaqueBackgroundForAllWindows == true or false
+  if n < 0 then return 0 end
+  if n > 1 then return 1 end
+  return n
 end
 
-function WSGH.Util.ApplyOpaqueWindowBackground(frame, windowKind, inset)
+local function CopyColor(color, fallback)
+  color = type(color) == "table" and color or {}
+  fallback = type(fallback) == "table" and fallback or { 1, 1, 1, 1 }
+  return {
+    ClampColorChannel(color.r or color[1], fallback.r or fallback[1]),
+    ClampColorChannel(color.g or color[2], fallback.g or fallback[2]),
+    ClampColorChannel(color.b or color[3], fallback.b or fallback[3]),
+    ClampColorChannel(color.a or color[4], fallback.a or fallback[4] or 1),
+  }
+end
+
+local function ColorsMatch(a, b)
+  a = CopyColor(a)
+  b = CopyColor(b)
+  for i = 1, 4 do
+    if math.abs((a[i] or 0) - (b[i] or 0)) > 0.001 then
+      return false
+    end
+  end
+  return true
+end
+
+function WSGH.Util.GetColorRoleGroups()
+  return WSGH.Const and WSGH.Const.COLOR_ROLES or {}
+end
+
+function WSGH.Util.GetDefaultColor(roleKey)
+  local defaults = WSGH.Const and WSGH.Const.COLOR_DEFAULTS or {}
+  return CopyColor(defaults and defaults[roleKey] or nil)
+end
+
+function WSGH.Util.GetColor(roleKey, fallback)
+  local defaultColor = WSGH.Util.GetDefaultColor(roleKey)
+  if fallback then
+    defaultColor = CopyColor(defaultColor, fallback)
+  end
+
+  local preferences = WSGH.Util.GetPreferences and WSGH.Util.GetPreferences() or nil
+  local storedColor = preferences and preferences.colors and preferences.colors[roleKey] or nil
+  if type(storedColor) == "table" then
+    return CopyColor(storedColor, defaultColor)
+  end
+  return defaultColor
+end
+
+function WSGH.Util.SetColor(roleKey, color)
+  if type(roleKey) ~= "string" or roleKey == "" then return end
+  local preferences = WSGH.Util.GetPreferences and WSGH.Util.GetPreferences() or nil
+  if not preferences then return end
+
+  preferences.colors = preferences.colors or {}
+  local normalized = CopyColor(color, WSGH.Util.GetDefaultColor(roleKey))
+  local defaultColor = WSGH.Util.GetDefaultColor(roleKey)
+  if ColorsMatch(normalized, defaultColor) then
+    preferences.colors[roleKey] = nil
+  else
+    preferences.colors[roleKey] = {
+      r = normalized[1],
+      g = normalized[2],
+      b = normalized[3],
+      a = normalized[4],
+    }
+  end
+end
+
+function WSGH.Util.ResetColor(roleKey)
+  local preferences = WSGH.Util.GetPreferences and WSGH.Util.GetPreferences() or nil
+  if preferences and preferences.colors then
+    preferences.colors[roleKey] = nil
+  end
+end
+
+function WSGH.Util.ResetAllColors()
+  local preferences = WSGH.Util.GetPreferences and WSGH.Util.GetPreferences() or nil
+  if preferences then
+    preferences.colors = {}
+  end
+end
+
+function WSGH.Util.HasCustomColors()
+  local preferences = WSGH.Util.GetPreferences and WSGH.Util.GetPreferences() or nil
+  if not (preferences and type(preferences.colors) == "table") then
+    return false
+  end
+  local defaults = WSGH.Const and WSGH.Const.COLOR_DEFAULTS or {}
+  for roleKey in pairs(preferences.colors) do
+    if defaults[roleKey] then
+      return true
+    end
+  end
+  return false
+end
+
+function WSGH.Util.SetTextColor(fontString, roleKey)
+  if not (fontString and fontString.SetTextColor) then return end
+  local color = WSGH.Util.GetColor(roleKey)
+  fontString:SetTextColor(color[1], color[2], color[3], color[4])
+end
+
+local buttonTextFontObjects = {}
+
+local function CopyFontObjectStyle(target, source)
+  if not (target and source) then return end
+  if target.SetFont and source.GetFont then
+    local font, size, flags = source:GetFont()
+    if font then
+      target:SetFont(font, size, flags)
+    end
+  end
+  if target.SetShadowColor and source.GetShadowColor then
+    target:SetShadowColor(source:GetShadowColor())
+  end
+  if target.SetShadowOffset and source.GetShadowOffset then
+    target:SetShadowOffset(source:GetShadowOffset())
+  end
+end
+
+local function GetButtonTextFontObject(button, roleKey)
+  local key = roleKey or "button.defaultText"
+  local fontObject = buttonTextFontObjects[key]
+  if not fontObject then
+    fontObject = CreateFont("WSGHButtonTextFont" .. key:gsub("[^%w]", "_"))
+    buttonTextFontObjects[key] = fontObject
+  end
+
+  local source = button
+    and button.GetFontString
+    and button:GetFontString()
+    or GameFontNormalSmall
+  CopyFontObjectStyle(fontObject, source)
+
+  local color = WSGH.Util.GetColor(key)
+  fontObject:SetTextColor(color[1], color[2], color[3], color[4])
+  return fontObject
+end
+
+function WSGH.Util.ApplyButtonTextColor(button, roleKey)
+  if not button then return end
+  local fontObject = GetButtonTextFontObject(button, roleKey)
+  if button.SetNormalFontObject then
+    button:SetNormalFontObject(fontObject)
+  end
+  if button.SetHighlightFontObject then
+    button:SetHighlightFontObject(fontObject)
+  end
+  if button.SetDisabledFontObject then
+    button:SetDisabledFontObject(fontObject)
+  end
+  if button.GetFontString and button:GetFontString() then
+    WSGH.Util.SetTextColor(button:GetFontString(), roleKey or "button.defaultText")
+  end
+end
+
+function WSGH.Util.SetTextureColor(texture, roleKey)
+  if not texture then return end
+  local color = WSGH.Util.GetColor(roleKey)
+  if texture.SetColorTexture then
+    texture:SetColorTexture(color[1], color[2], color[3], color[4])
+  elseif texture.SetVertexColor then
+    texture:SetVertexColor(color[1], color[2], color[3], color[4])
+  end
+end
+
+local function GetWindowBackgroundRole(windowKind)
+  if windowKind == "shoppingReminder" then
+    return "window.reminderBackground"
+  end
+  return "window.background"
+end
+
+function WSGH.Util.ApplyWindowBackground(frame, windowKind, inset)
   if not frame then return end
 
-  local useOpaque = WSGH.Util.ShouldUseOpaqueWindowBackground(windowKind)
   local background = frame.wsghOpaqueBackground
   if not background then
     background = frame:CreateTexture(nil, "BACKGROUND")
@@ -235,13 +405,13 @@ function WSGH.Util.ApplyOpaqueWindowBackground(frame, windowKind, inset)
   background:SetPoint("TOPLEFT", backgroundInset, -backgroundInset)
   background:SetPoint("BOTTOMRIGHT", -backgroundInset, backgroundInset)
   background:SetTexture("Interface\\Buttons\\WHITE8x8")
-  background:SetVertexColor(
-    OPAQUE_WINDOW_COLOR[1],
-    OPAQUE_WINDOW_COLOR[2],
-    OPAQUE_WINDOW_COLOR[3],
-    OPAQUE_WINDOW_COLOR[4]
-  )
-  background:SetShown(useOpaque)
+  local color = WSGH.Util.GetColor(GetWindowBackgroundRole(windowKind))
+  background:SetVertexColor(color[1], color[2], color[3], color[4])
+  background:SetShown((tonumber(color[4]) or 0) > 0)
+end
+
+function WSGH.Util.ApplyOpaqueWindowBackground(frame, windowKind, inset)
+  WSGH.Util.ApplyWindowBackground(frame, windowKind, inset)
 end
 
 function WSGH.Util.GetDefaultTinkerForSlot(slotId)

--- a/WowSimsGearHelper.toc
+++ b/WowSimsGearHelper.toc
@@ -3,7 +3,7 @@
 ## Notes: WSGH helps apply WowSims exports with guided gear changes, highlights, and shopping lists.
 ## IconTexture: Interface\AddOns\WowSimsGearHelper\WowSimsGearHelper_icon.tga
 ## Author: Blazz
-## Version: 1.3.2-alpha.1
+## Version: 1.4.0-beta.1
 ## OptionalDeps: Masque, ReforgeLite
 ## SavedVariablesPerCharacter: WowSimsGearHelperDB
 


### PR DESCRIPTION
## Summary

Adds a new Colors settings section for customizing addon UI colors, including previews, presets, swatches, help text, and reset controls.

## What changed

* Added focused previews for configurable color roles.
* Added per-color help icons, swatches, preset dropdowns, and reset actions.
* Added a confirmed reset-all action for color settings.
* Added customizable color roles for action button text, window backgrounds, row titles, shopping text, highlight glow/labels, and task-priority states.
* Replaced the old opaque-background setting with customizable window background colors.

## Why

This started from a request to make completed socketing states easier to distinguish at a glance by greying out “done” text. Since the same color system already touched several related UI states, the change was expanded into a broader Colors settings section so users can customize the full set instead of only one hardcoded state.
