### PR TITLE
Release/v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project are documented in this file.
 - Added localized tooltip support for Russian clients when detecting item upgrade levels and engineering tinkers.
 - Upgrade level detection now prefers the client's localized tooltip format when Blizzard exposes it.
 
+### Fixed
+- Upgrade shopping now uses Valor for non-Warforged Siege of Orgrimmar items and Justice for Warforged items, with a manual currency override in settings (defaults to Auto).
+
 ## [1.4.0] - 14 Jul, 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [1.4.1] - 03 Aug, 2026
+
+### Added
+- Added localized tooltip support for Russian clients when detecting item upgrade levels and engineering tinkers.
+- Upgrade level detection now prefers the client's localized tooltip format when Blizzard exposes it.
+
 ## [1.4.0] - 14 Jul, 2026
 
 ### Added

--- a/Constants.lua
+++ b/Constants.lua
@@ -199,7 +199,7 @@ WSGH.Const.TASK_PRIORITY_TYPES = {
   {
     key = "UPGRADE_ITEM",
     label = "Upgrade items",
-    description = "Item upgrade tasks using the selected currency preference.",
+    description = "Item upgrade tasks using automatic or overridden currency rules.",
   },
   {
     key = "REFORGE_ITEM",
@@ -306,6 +306,23 @@ WSGH.Const.VALOR_POINTS_PER_JP_COMMENDATION = 125
 WSGH.Const.JUSTICE_POINTS_PER_COMMENDATION_NON_GUILD = 500
 WSGH.Const.JUSTICE_POINTS_PER_COMMENDATION_GUILD = 600
 
+WSGH.Const.UPGRADE_CURRENCY_MODES = {
+  { value = "AUTO", text = "Auto" },
+  { value = "JUSTICE", text = "Force Justice" },
+  { value = "VALOR", text = "Force Valor" },
+}
+WSGH.Const.SOO_NON_WARFORGED_BASE_ITEM_LEVELS = {
+  [528] = true, -- Celestials / Siege of Orgrimmar LFR
+  [540] = true, -- Siege of Orgrimmar Flexible
+  [553] = true, -- Siege of Orgrimmar Normal
+  [566] = true, -- Siege of Orgrimmar Heroic
+}
+WSGH.Const.SOO_WARFORGED_BASE_ITEM_LEVELS = {
+  [546] = true, -- Siege of Orgrimmar Flexible Warforged
+  [559] = true, -- Siege of Orgrimmar Normal Warforged
+  [572] = true, -- Siege of Orgrimmar Heroic Warforged
+}
+
 WSGH.Const.AUCTION_CHAT_POLL_INTERVAL_SECONDS = 0.5
 WSGH.Const.AUCTION_CHAT_RESYNC_HISTORY_LINES = 80
 
@@ -357,6 +374,10 @@ WSGH.Const.UI = {
       bottomPadding = 36,
       rightInset = 28,
       mouseWheelStep = 36,
+    },
+    upgradeCurrency = {
+      dropdownWidth = 180,
+      buttonWidth = 180,
     },
     taskPriority = {
       xOffset = 320,

--- a/Core.lua
+++ b/Core.lua
@@ -35,7 +35,8 @@ local function EnsureDB()
       restoreWindowAfterReforgeNpc = false,
       tinkers = {},
       colors = {},
-      upgradeCurrency = "JUSTICE",
+      upgradeCurrency = "AUTO",
+      upgradeCurrencyMode = "AUTO",
       useValorForUpgrades = false,
       taskPriorityOrder = WSGH.Util.GetDefaultTaskPriorityOrder and WSGH.Util.GetDefaultTaskPriorityOrder() or {},
     }
@@ -52,8 +53,9 @@ local function EnsureDB()
   if type(prefs.colors) ~= "table" then prefs.colors = {} end
   if prefs.minimap == nil then prefs.minimap = { hide = false } end
   if prefs.minimap.hide == nil then prefs.minimap.hide = false end
-  if prefs.upgradeCurrency == nil then prefs.upgradeCurrency = "JUSTICE" end
-  if prefs.useValorForUpgrades == nil then prefs.useValorForUpgrades = (prefs.upgradeCurrency == "VALOR") end
+  if WSGH.Util.NormalizeUpgradeCurrencyPreferences then
+    WSGH.Util.NormalizeUpgradeCurrencyPreferences(prefs)
+  end
   if WSGH.Util.NormalizeTaskPriorityOrder then
     prefs.taskPriorityOrder = WSGH.Util.NormalizeTaskPriorityOrder(prefs.taskPriorityOrder)
   end

--- a/Core.lua
+++ b/Core.lua
@@ -3,7 +3,7 @@ local WSGH = _G.WowSimsGearHelper or {}
 _G.WowSimsGearHelper = WSGH
 
 WSGH.ADDON_NAME = ADDON_NAME
-WSGH.VERSION = "1.4.0"
+WSGH.VERSION = "1.4.1"
 
 local function EnsureDB()
   if type(_G.WowSimsGearHelperDB) ~= "table" then

--- a/Data/Enchants.lua
+++ b/Data/Enchants.lua
@@ -430,6 +430,16 @@ WSGH.Data.TinkerTooltipTextByLocale = {
     [126731] = { "synapse springs", "Your highest stat is always chosen" },
     [1250229] = { "synapse springs", "Your highest stat is always chosen" },
   },
+  -- Verified against live ruRU (Cataclysm/MoP Classic) tooltips. Case is
+  -- intentional/preserved as shown in-game: Lua's string.lower() does not
+  -- fold Cyrillic casing, so matches must use the exact capitalization
+  -- Blizzard displays (these all start mid-sentence after "Использование:").
+  ruRU = {
+    [55016] = { "Значительно повышает вашу скорость бега" }, -- Nitro Boosts
+    [126392] = { "Уменьшает вашу скорость падения" }, -- Goblin Glider
+    [126731] = { "какой из этих показателей наивысший" }, -- Synapse Springs (Mark II)
+    [1250229] = { "какой из этих показателей наивысший" }, -- Synapse Springs (Mark I)
+  },
 }
 
 -- Enchants applied via non-vellum consumables (e.g., armor kits, inscriptions).
@@ -676,5 +686,3 @@ function Enchants.GetDisplayInfo(enchantId)
 end
 
 WSGH.Data.Enchants = Enchants
-
-

--- a/Data/Tooltip.lua
+++ b/Data/Tooltip.lua
@@ -1,0 +1,11 @@
+local WSGH = _G.WowSimsGearHelper or {}
+_G.WowSimsGearHelper = WSGH
+WSGH.Data = WSGH.Data or {}
+
+-- Fallback labels used by Scan/Tooltip.lua when Blizzard's localized upgrade
+-- format string is unavailable. Non-ASCII labels preserve in-game casing.
+WSGH.Data.UpgradeLevelLabelsByLocale = {
+  enUS = { "Upgrade Level" },
+  enGB = { "Upgrade Level" },
+  ruRU = { "Уровень улучшения" },
+}

--- a/Diff/Engine.lua
+++ b/Diff/Engine.lua
@@ -47,6 +47,30 @@ local function GetExpectedUpgradeStep(planSlot)
   return trailingNumber
 end
 
+local function GetBaseItemLevelForUpgrade(equippedSlot)
+  local itemLevel = tonumber(equippedSlot and equippedSlot.itemLevel) or 0
+  if itemLevel <= 0 then return 0 end
+
+  local upgradeLevel = tonumber(equippedSlot and equippedSlot.upgradeLevel) or 0
+  if upgradeLevel < 0 then upgradeLevel = 0 end
+  return itemLevel - (upgradeLevel * 4)
+end
+
+local function GetAutoUpgradeCurrencyForSlot(equippedSlot)
+  local baseItemLevel = GetBaseItemLevelForUpgrade(equippedSlot)
+  local currentItemLevel = tonumber(equippedSlot and equippedSlot.itemLevel) or 0
+  local nonWarforgedLevels = WSGH.Const and WSGH.Const.SOO_NON_WARFORGED_BASE_ITEM_LEVELS or {}
+  local warforgedLevels = WSGH.Const and WSGH.Const.SOO_WARFORGED_BASE_ITEM_LEVELS or {}
+
+  if warforgedLevels[baseItemLevel] then
+    return "JUSTICE", baseItemLevel, currentItemLevel, "SOO_WARFORGED"
+  end
+  if nonWarforgedLevels[baseItemLevel] then
+    return "VALOR", baseItemLevel, currentItemLevel, "SOO"
+  end
+  return "JUSTICE", baseItemLevel, currentItemLevel, "UNKNOWN"
+end
+
 local function MaxExpectedSocketIndex(planSlot)
   local maxIdx = tonumber(planSlot.expectedGemSocketCount) or 0
   for socketIndex in pairs(planSlot.expectedGemsByIndex or {}) do
@@ -367,6 +391,7 @@ local function BuildUpgradeTasksForSlot(planSlot, equippedSlot)
   local expectedUpgradeStep = GetExpectedUpgradeStep(planSlot)
   local currentUpgradeLevel = tonumber(equippedSlot.upgradeLevel) or 0
   local currentUpgradeMax = tonumber(equippedSlot.upgradeMax) or 0
+  local upgradeCurrencyKey, upgradeBaseItemLevel, upgradeItemLevel, upgradeCurrencySource = GetAutoUpgradeCurrencyForSlot(equippedSlot)
 
   if expectedItemId == 0 or equippedItemId ~= expectedItemId then
     return tasks
@@ -399,6 +424,10 @@ local function BuildUpgradeTasksForSlot(planSlot, equippedSlot)
       haveUpgradeStep = currentUpgradeLevel,
       wantUpgradeStep = step,
       upgradeMax = currentUpgradeMax,
+      upgradeCurrencyKey = upgradeCurrencyKey,
+      upgradeCurrencySource = upgradeCurrencySource,
+      upgradeBaseItemLevel = upgradeBaseItemLevel,
+      upgradeItemLevel = upgradeItemLevel,
       remainingSteps = remaining,
       status = WSGH.Const.STATUS_WRONG,
     }
@@ -699,6 +728,8 @@ function WSGH.Diff.Engine.Build(plan, equipped, bagIndex)
         expectedItemId = planSlot.expectedItemId,
         equippedItemId = eqSlot.itemId,
         equippedLink = eqSlot.itemLink,
+        equippedItemLevel = tonumber(eqSlot.itemLevel) or 0,
+        equippedBaseItemLevel = GetBaseItemLevelForUpgrade(eqSlot),
         bagLocations = bagIndex and bagIndex[planSlot.expectedItemId] or nil,
         hasExpectedInBags = bagIndex and bagIndex[planSlot.expectedItemId] and #bagIndex[planSlot.expectedItemId] > 0 or false,
 
@@ -814,10 +845,13 @@ function WSGH.Debug.DumpDiffRow(slotId)
       end
       if row.upgradeTasks then
         for _, t in ipairs(row.upgradeTasks) do
-          WSGH.Util.Print(("Upgrade task: have=%s want=%s target=%s status=%s"):format(
+          WSGH.Util.Print(("Upgrade task: have=%s want=%s target=%s currency=%s baseIlvl=%s source=%s status=%s"):format(
             tostring(t.haveUpgradeStep),
             tostring(t.wantUpgradeStep),
             tostring(t.targetUpgradeStep),
+            tostring(t.upgradeCurrencyKey),
+            tostring(t.upgradeBaseItemLevel),
+            tostring(t.upgradeCurrencySource),
             tostring(t.status)
           ))
         end

--- a/README.md
+++ b/README.md
@@ -59,9 +59,13 @@ Please use GitHub Issues and include as much context as possible.
 
 Limitations
 -----------
-- At this time I only support the English client and language. If Blizzard decides to continue into Warlords of Draenor, I'll likely extend with additional locale support.
+- English clients are fully supported, and Russian clients have localized tooltip support for upgrade levels and engineering tinkers. Support for more locales is welcome; please open a feature request with your game client locale, and I'll follow up with the exact tooltip text needed.
 - Reforging is handled by syncing to ReforgeLite Classic when it is installed and enabled; WSGH only guides and confirms from item links.
 - The addon follows the data you import and attempts to flag issues, but you should still verify the result yourself.
+
+Contributors
+------------
+- **Webbuster** from Discord provided the Russian tooltip phrases used to detect item upgrade levels, Nitro Boosts, Goblin Glider, and Synapse Springs.
 
 Attribution
 -----------

--- a/Scan/Tooltip.lua
+++ b/Scan/Tooltip.lua
@@ -389,24 +389,104 @@ local function DetectTinkerFromLines(lines)
   return bestSpellId
 end
 
+local upgradeLinePattern -- false = unavailable, nil = not built yet, string = ready
+
+-- Builds a locale-agnostic Lua pattern from the client's own localized global
+-- string (e.g. "Upgrade Level: %s %d/%d" on enUS, but properly translated on
+-- every other client language, including ruRU). This avoids hardcoding any
+-- single language's tooltip text.
+local function BuildUpgradeLinePattern()
+  local fmt = _G.ITEM_UPGRADE_TOOLTIP_FORMAT_STRING
+  if type(fmt) ~= "string" or fmt == "" then return nil end
+
+  -- Escape Lua pattern "magic" characters, but deliberately skip "%" itself
+  -- so the %s/%d format markers below survive untouched.
+  local escaped = fmt:gsub("([%^%$%(%)%.%[%]%*%+%-%?])", "%%%1")
+  -- %s (e.g. an upgrade track name) is not something we need to capture.
+  escaped = escaped:gsub("%%s", ".-")
+  -- %d becomes a capture group; the two captures we get back (in order)
+  -- are always "current" and "max", regardless of whether %s is present.
+  escaped = escaped:gsub("%%d", "(%%d+)")
+  return escaped
+end
+
+local function GetUpgradeLinePattern()
+  if upgradeLinePattern == nil then
+    upgradeLinePattern = BuildUpgradeLinePattern() or false
+  end
+  return upgradeLinePattern or nil
+end
+
+local function GetUpgradeLevelLabels()
+  local locale = (type(GetLocale) == "function" and GetLocale()) or "enUS"
+  local labelsByLocale = WSGH.Data and WSGH.Data.UpgradeLevelLabelsByLocale or {}
+  local labels = labelsByLocale[locale]
+  if labels then return labels end
+  -- Unknown locale: fall back to enUS labels (better than nothing) plus
+  -- the generic lowercase check further down still applies.
+  return labelsByLocale.enUS or {}
+end
+
+local function MatchUpgradeLevelAfterLabel(line, label)
+  local labelStart, labelEnd = line:find(label, 1, true)
+  if not labelStart then return nil, nil end
+  local rest = line:sub(labelEnd + 1)
+  local cur, max = rest:match("(%d+)%s*/%s*(%d+)")
+  if cur and max then
+    return tonumber(cur), tonumber(max)
+  end
+  return nil, nil
+end
+
 local function DetectUpgradeLevelFromLines(lines)
   local bestCurrent = 0
   local bestMax = 0
   local found = false
 
+  local pattern = GetUpgradeLinePattern()
+  local labels = GetUpgradeLevelLabels()
+
   for _, line in ipairs(lines or {}) do
     if type(line) == "string" and line ~= "" then
-      local lowered = (WSGH.Util and WSGH.Util.SafeLower and WSGH.Util.SafeLower(line)) or line:lower()
-      if lowered:find("upgrade level", 1, true) then
-        local cur, max = line:match("(%d+)%s*/%s*(%d+)")
-        cur = tonumber(cur) or 0
-        max = tonumber(max) or 0
-        if max > 0 then
-          found = true
-          if max > bestMax or (max == bestMax and cur > bestCurrent) then
-            bestCurrent = cur
-            bestMax = max
+      local cur, max
+
+      -- Primary: match against the client's own localized format string,
+      -- when that global string is available on this client build.
+      if pattern then
+        local a, b = line:match(pattern)
+        if a and b then
+          cur, max = tonumber(a), tonumber(b)
+        end
+      end
+
+      -- Secondary: explicit per-locale label list.
+      if not cur then
+        for _, label in ipairs(labels) do
+          local a, b = MatchUpgradeLevelAfterLabel(line, label)
+          if a and b then
+            cur, max = a, b
+            break
           end
+        end
+      end
+
+      -- Tertiary: legacy enUS-only lowercase substring match, kept as a
+      -- last-resort safety net.
+      if not cur then
+        local lowered = (WSGH.Util and WSGH.Util.SafeLower and WSGH.Util.SafeLower(line)) or line:lower()
+        if lowered:find("upgrade level", 1, true) then
+          local c, m = line:match("(%d+)%s*/%s*(%d+)")
+          cur, max = tonumber(c), tonumber(m)
+        end
+      end
+
+      cur = cur or 0
+      max = max or 0
+      if max > 0 then
+        found = true
+        if max > bestMax or (max == bestMax and cur > bestCurrent) then
+          bestCurrent = cur
+          bestMax = max
         end
       end
     end

--- a/UI/Settings.lua
+++ b/UI/Settings.lua
@@ -1082,30 +1082,56 @@ local function BuildOptionsPanel()
   end)
   minimapCheck:SetScript("OnLeave", GameTooltip_Hide)
 
-  local useValorCheck = CreateFrame("CheckButton", nil, optionsContent, "ChatConfigCheckButtonTemplate")
-  useValorCheck:SetPoint("TOPLEFT", minimapCheck, "BOTTOMLEFT", 0, -6)
-  useValorCheck.Text:SetText("Use Valor for upgrades")
-  useValorCheck:SetChecked(preferences.useValorForUpgrades == true)
-  useValorCheck:SetScript("OnClick", function(self)
-    local preferencesTable = GetPreferences()
-    if not preferencesTable then return end
-    local useValor = self:GetChecked() and true or false
-    preferencesTable.useValorForUpgrades = useValor
-    preferencesTable.upgradeCurrency = useValor and "VALOR" or "JUSTICE"
-    if WSGH.UI and WSGH.UI.Shopping and WSGH.UI.Shopping.UpdateShoppingList then
-      WSGH.UI.Shopping.UpdateShoppingList()
+  local upgradeCurrencyLabel = optionsContent:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+  upgradeCurrencyLabel:SetPoint("TOPLEFT", minimapCheck, "BOTTOMLEFT", 18, -10)
+  upgradeCurrencyLabel:SetText("Upgrade currency:")
+
+  local upgradeCurrencyDrop = CreateFrame("Frame", "WSGHUpgradeCurrencyMode", optionsContent, "UIDropDownMenuTemplate")
+  upgradeCurrencyDrop:SetPoint("TOPLEFT", upgradeCurrencyLabel, "BOTTOMLEFT", -16, -4)
+  local upgradeCurrencyLayout = WSGH.Const.UI.settings.upgradeCurrency or {}
+  UIDropDownMenu_SetWidth(upgradeCurrencyDrop, tonumber(upgradeCurrencyLayout.dropdownWidth) or 180)
+  UIDropDownMenu_SetButtonWidth(upgradeCurrencyDrop, tonumber(upgradeCurrencyLayout.buttonWidth) or 180)
+
+  UIDropDownMenu_Initialize(upgradeCurrencyDrop, function(_, level)
+    local preferencesTable = GetPreferences() or {}
+    local current = preferencesTable.upgradeCurrencyMode or "AUTO"
+    for _, opt in ipairs(WSGH.Const.UPGRADE_CURRENCY_MODES or {}) do
+      local info = UIDropDownMenu_CreateInfo()
+      info.text = opt.text
+      info.value = opt.value
+      info.func = function()
+        UIDropDownMenu_SetSelectedValue(upgradeCurrencyDrop, opt.value)
+        UIDropDownMenu_SetText(upgradeCurrencyDrop, opt.text)
+        preferencesTable.upgradeCurrencyMode = opt.value
+        preferencesTable.upgradeCurrency = opt.value
+        preferencesTable.useValorForUpgrades = opt.value == "VALOR"
+        if WSGH.UI and WSGH.UI.Shopping and WSGH.UI.Shopping.UpdateShoppingList then
+          WSGH.UI.Shopping.UpdateShoppingList()
+        end
+      end
+      info.checked = (opt.value == current)
+      UIDropDownMenu_AddButton(info, level)
     end
   end)
-  useValorCheck:SetScript("OnEnter", function(self)
+
+  local initialUpgradeCurrencyMode = preferences.upgradeCurrencyMode or "AUTO"
+  for _, opt in ipairs(WSGH.Const.UPGRADE_CURRENCY_MODES or {}) do
+    if opt.value == initialUpgradeCurrencyMode then
+      UIDropDownMenu_SetSelectedValue(upgradeCurrencyDrop, opt.value)
+      UIDropDownMenu_SetText(upgradeCurrencyDrop, opt.text)
+      break
+    end
+  end
+  upgradeCurrencyDrop:SetScript("OnEnter", function(self)
     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-    GameTooltip:SetText("Use Valor for upgrades", 1, 1, 1)
-    GameTooltip:AddLine("When enabled, shopping upgrade currency info uses Valor instead of Justice.", nil, nil, nil, true)
+    GameTooltip:SetText("Upgrade currency", 1, 1, 1)
+    GameTooltip:AddLine("Auto uses Valor for non-Warforged Siege of Orgrimmar items and Justice for Warforged items. Force a currency if Blizzard changes upgrade costs.", nil, nil, nil, true)
     GameTooltip:Show()
   end)
-  useValorCheck:SetScript("OnLeave", GameTooltip_Hide)
+  upgradeCurrencyDrop:SetScript("OnLeave", GameTooltip_Hide)
 
   local reforgeReminderCheck = CreateFrame("CheckButton", nil, optionsContent, "ChatConfigCheckButtonTemplate")
-  reforgeReminderCheck:SetPoint("TOPLEFT", useValorCheck, "BOTTOMLEFT", 0, -6)
+  reforgeReminderCheck:SetPoint("TOPLEFT", upgradeCurrencyDrop, "BOTTOMLEFT", -2, -10)
   reforgeReminderCheck.Text:SetText("Show manual reforge reminder after import")
   reforgeReminderCheck:SetChecked(preferences.showReforgeReminderAfterImport ~= false)
   reforgeReminderCheck:SetScript("OnClick", function(self)

--- a/UI/Shopping.lua
+++ b/UI/Shopping.lua
@@ -678,10 +678,17 @@ function WSGH.UI.Shopping.GetRowPurchaseNeeds(row, bagIndex, includeAvailable)
   return needs
 end
 
-local function GetUpgradeCurrencyConfig()
+local function GetUpgradeCurrencyMode()
   local preferences = WSGH.Util and WSGH.Util.GetPreferences and WSGH.Util.GetPreferences() or {}
-  local useValor = preferences and preferences.useValorForUpgrades == true
-  if useValor then
+  local mode = preferences and preferences.upgradeCurrencyMode or nil
+  if mode == "JUSTICE" or mode == "VALOR" then
+    return mode
+  end
+  return "AUTO"
+end
+
+local function GetUpgradeCurrencyConfig(currencyKey)
+  if currencyKey == "VALOR" then
     return {
       key = "VALOR",
       short = "VP",
@@ -700,6 +707,19 @@ local function GetUpgradeCurrencyConfig()
     commendationItemId = WSGH.Const.JUSTICE_POINTS_COMMENDATION_ITEM_ID,
     cap = 4000,
   }
+end
+
+local function GetCurrencyKeyForUpgradeTask(task)
+  local mode = GetUpgradeCurrencyMode()
+  if mode == "JUSTICE" or mode == "VALOR" then
+    return mode
+  end
+
+  local key = task and task.upgradeCurrencyKey or nil
+  if key == "VALOR" or key == "JUSTICE" then
+    return key
+  end
+  return "JUSTICE"
 end
 
 local function RefreshAfterPurchase()
@@ -842,7 +862,7 @@ function WSGH.UI.Shopping.UpdateShoppingList()
   local hasPendingEquipTasks = false
 
   if diff and diff.rows then
-    local upgradeStepsNeeded = 0
+    local upgradeStepsByCurrency = {}
     for _, row in ipairs(diff.rows) do
       if row.rowStatus == "WRONG_ITEM" then
         hasPendingEquipTasks = true
@@ -853,65 +873,70 @@ function WSGH.UI.Shopping.UpdateShoppingList()
 
       for _, task in ipairs(row.upgradeTasks or {}) do
         if task.status and task.status ~= WSGH.Const.STATUS_OK then
-          upgradeStepsNeeded = upgradeStepsNeeded + 1
+          local currencyKey = GetCurrencyKeyForUpgradeTask(task)
+          upgradeStepsByCurrency[currencyKey] = (upgradeStepsByCurrency[currencyKey] or 0) + 1
         end
       end
     end
 
-    if upgradeStepsNeeded > 0 then
-      local currencyConfig = GetUpgradeCurrencyConfig()
-      local commendationItemId = tonumber(currencyConfig.commendationItemId)
-      local commendationsInBags = CountItemInBags(commendationItemId, bagIndex)
-      local currencyAmount, currencyIcon = GetCurrencyAmountAndIcon(currencyConfig.currencyId)
-      local currencyPerUpgradeStep = tonumber(currencyConfig.perUpgradeStep)
-      local currencyCap = tonumber(currencyConfig.cap)
-      local currencyNeeded = upgradeStepsNeeded * currencyPerUpgradeStep
-      local currencyMissing = currencyNeeded - currencyAmount
-      if currencyMissing < 0 then currencyMissing = 0 end
+    local hasUpgradeSteps = false
+    local hasMissingJusticeCurrency = false
+    local currencyOrder = { "JUSTICE", "VALOR" }
+    for _, currencyKey in ipairs(currencyOrder) do
+      local upgradeStepsNeeded = tonumber(upgradeStepsByCurrency[currencyKey]) or 0
+      if upgradeStepsNeeded > 0 then
+        hasUpgradeSteps = true
+        local currencyConfig = GetUpgradeCurrencyConfig(currencyKey)
+        local commendationItemId = tonumber(currencyConfig.commendationItemId)
+        local commendationsInBags = CountItemInBags(commendationItemId, bagIndex)
+        local currencyAmount, currencyIcon = GetCurrencyAmountAndIcon(currencyConfig.currencyId)
+        local currencyPerUpgradeStep = tonumber(currencyConfig.perUpgradeStep)
+        local currencyCap = tonumber(currencyConfig.cap)
+        local currencyNeeded = upgradeStepsNeeded * currencyPerUpgradeStep
+        local currencyMissing = currencyNeeded - currencyAmount
+        if currencyMissing < 0 then currencyMissing = 0 end
 
-      local jpPerCommNonGuild = WSGH.Const.JUSTICE_POINTS_PER_COMMENDATION_NON_GUILD
-      local jpPerCommGuild = WSGH.Const.JUSTICE_POINTS_PER_COMMENDATION_GUILD
-      local valorPerJpComm = WSGH.Const.VALOR_POINTS_PER_JP_COMMENDATION
-      local isInGuild = (IsInGuild and IsInGuild()) and true or false
-      local jpPerComm = isInGuild and jpPerCommGuild or jpPerCommNonGuild
-      local neededComm = 0
-      local neededValor = 0
-      if currencyConfig.key == "JUSTICE" and currencyMissing > 0 then
-        neededComm = math.ceil(currencyMissing / math.max(jpPerComm, 1))
-        neededValor = neededComm * valorPerJpComm
-      end
+        local jpPerCommNonGuild = WSGH.Const.JUSTICE_POINTS_PER_COMMENDATION_NON_GUILD
+        local jpPerCommGuild = WSGH.Const.JUSTICE_POINTS_PER_COMMENDATION_GUILD
+        local valorPerJpComm = WSGH.Const.VALOR_POINTS_PER_JP_COMMENDATION
+        local isInGuild = (IsInGuild and IsInGuild()) and true or false
+        local jpPerComm = isInGuild and jpPerCommGuild or jpPerCommNonGuild
+        local neededComm = 0
+        local neededValor = 0
+        if currencyConfig.key == "JUSTICE" and currencyMissing > 0 then
+          neededComm = math.ceil(currencyMissing / math.max(jpPerComm, 1))
+          neededValor = neededComm * valorPerJpComm
+          hasMissingJusticeCurrency = true
+        end
 
-      if currencyMissing > 0 then
-        local bucket = itemsByCategory["Other"] or {}
-        itemsByCategory["Other"] = bucket
-        bucket[#bucket + 1] = {
-          isCurrency = true,
-          currencyKey = currencyConfig.key,
-          currencyShort = currencyConfig.short,
-          currencyId = currencyConfig.currencyId,
-          currencyAmount = currencyAmount,
-          currencyCap = currencyCap,
-          currencyIcon = currencyIcon,
-          upgradeStepsNeeded = upgradeStepsNeeded,
-          currencyNeeded = currencyNeeded,
-          currencyMissing = currencyMissing,
-          isInGuild = isInGuild,
-          jpPerComm = jpPerComm,
-          neededComm = neededComm,
-          neededValor = neededValor,
-          actionItemId = commendationItemId,
-          actionItemCount = commendationsInBags,
-          category = "Other",
-        }
+        if currencyMissing > 0 then
+          local bucket = itemsByCategory["Other"] or {}
+          itemsByCategory["Other"] = bucket
+          bucket[#bucket + 1] = {
+            isCurrency = true,
+            currencyKey = currencyConfig.key,
+            currencyShort = currencyConfig.short,
+            currencyId = currencyConfig.currencyId,
+            currencyAmount = currencyAmount,
+            currencyCap = currencyCap,
+            currencyIcon = currencyIcon,
+            upgradeStepsNeeded = upgradeStepsNeeded,
+            currencyNeeded = currencyNeeded,
+            currencyMissing = currencyMissing,
+            isInGuild = isInGuild,
+            jpPerComm = jpPerComm,
+            neededComm = neededComm,
+            neededValor = neededValor,
+            actionItemId = commendationItemId,
+            actionItemCount = commendationsInBags,
+            category = "Other",
+          }
+        end
       end
+    end
 
-      if currencyMissing <= 0 and jpHighlightItemId then
-        WSGH.UI.Shopping.ClearJPHighlight()
-      end
-    else
-      if jpHighlightItemId then
-        WSGH.UI.Shopping.ClearJPHighlight()
-      end
+    if (not hasUpgradeSteps or not hasMissingJusticeCurrency) and jpHighlightItemId then
+      WSGH.UI.Shopping.ClearJPHighlight()
     end
   end
 
@@ -1111,7 +1136,7 @@ function WSGH.UI.Shopping.UpdateShoppingList()
               end
             end
 
-            entry.search:SetShown(true)
+            entry.search:SetShown(actionItemId ~= 0)
             entry.search:SetEnabled(actionItemId ~= 0)
             entry.search.itemId = actionItemId
             entry.search:SetWidth(WSGH.Const.UI.shopping.searchButton.width)

--- a/Util.lua
+++ b/Util.lua
@@ -93,6 +93,23 @@ function WSGH.Util.NormalizeTaskPriorityOrder(order)
   return normalized
 end
 
+function WSGH.Util.NormalizeUpgradeCurrencyPreferences(prefs)
+  if type(prefs) ~= "table" then return "AUTO" end
+
+  local mode = prefs.upgradeCurrencyMode
+  if mode == nil then
+    mode = "AUTO"
+  end
+  if mode ~= "AUTO" and mode ~= "JUSTICE" and mode ~= "VALOR" then
+    mode = "AUTO"
+  end
+
+  prefs.upgradeCurrencyMode = mode
+  prefs.upgradeCurrency = mode
+  prefs.useValorForUpgrades = mode == "VALOR"
+  return mode
+end
+
 function WSGH.Util.GetTaskPriorityOrder()
   local preferences = WSGH.Util.GetPreferences and WSGH.Util.GetPreferences() or nil
   return WSGH.Util.NormalizeTaskPriorityOrder(preferences and preferences.taskPriorityOrder or nil)
@@ -197,11 +214,8 @@ function WSGH.Util.GetPreferences()
   if prefs.minimap.hide == nil then
     prefs.minimap.hide = false
   end
-  if prefs.upgradeCurrency == nil then
-    prefs.upgradeCurrency = "JUSTICE"
-  end
-  if prefs.useValorForUpgrades == nil then
-    prefs.useValorForUpgrades = (prefs.upgradeCurrency == "VALOR")
+  if WSGH.Util.NormalizeUpgradeCurrencyPreferences then
+    WSGH.Util.NormalizeUpgradeCurrencyPreferences(prefs)
   end
   if type(prefs.colors) ~= "table" then
     prefs.colors = {}

--- a/WowSimsGearHelper.toc
+++ b/WowSimsGearHelper.toc
@@ -14,6 +14,7 @@ Libs/Json.lua
 Constants.lua
 Data/Enchants.lua
 Data/Gems.lua
+Data/Tooltip.lua
 Util.lua
 
 Importers/WowSims.lua

--- a/WowSimsGearHelper.toc
+++ b/WowSimsGearHelper.toc
@@ -3,7 +3,7 @@
 ## Notes: WSGH helps apply WowSims exports with guided gear changes, highlights, and shopping lists.
 ## IconTexture: Interface\AddOns\WowSimsGearHelper\WowSimsGearHelper_icon.tga
 ## Author: Blazz
-## Version: 1.4.0
+## Version: 1.4.1
 ## OptionalDeps: Masque, ReforgeLite
 ## SavedVariablesPerCharacter: WowSimsGearHelperDB
 


### PR DESCRIPTION
## Summary

Prepare WowSims Gear Helper 1.4.1 with targeted locale support and an upgrade currency fix for Siege of Orgrimmar items.

## What changed

- Added localized tooltip support for Russian clients when detecting item upgrade levels and engineering tinkers.
- Added contributor acknowledgement for the Russian tooltip phrases provided by **Webbuster** from Discord.
- Updated upgrade shopping so non-Warforged Siege of Orgrimmar items use Valor and Warforged items use Justice.
- Replaced the old upgrade currency checkbox with an `Auto / Force Justice / Force Valor` setting.

## Why

Russian client users can now get correct upgrade/tinker detection for the supported tooltip phrases, and Siege of Orgrimmar upgrade shopping now reflects Blizzard’s current JP/Valor currency behavior while keeping a manual override available if costs change again.